### PR TITLE
Add citation page to website

### DIFF
--- a/contents.html
+++ b/contents.html
@@ -80,6 +80,7 @@ if ("matplotlib.sourceforge.net" == document.location.hostname ||
         <li><a href="search.html">search</a>|&nbsp;</li>
         <li><a href="examples/index.html">examples</a>|&nbsp;</li>
         <li><a href="gallery.html">gallery</a>|&nbsp;</li>
+        <li><a href="citing.html">citation</a>|&nbsp;</li>
         <li><a href="#">docs</a> &raquo;</li>
  
       </ul>
@@ -254,6 +255,7 @@ if ("matplotlib.sourceforge.net" == document.location.hostname ||
         <li><a href="search.html">search</a>|&nbsp;</li>
         <li><a href="examples/index.html">examples</a>|&nbsp;</li>
         <li><a href="gallery.html">gallery</a>|&nbsp;</li>
+        <li><a href="citing.html">citation</a>|&nbsp;</li>
         <li><a href="#">docs</a> &raquo;</li>
  
       </ul>

--- a/examples/index.html
+++ b/examples/index.html
@@ -76,6 +76,7 @@ if ("matplotlib.sourceforge.net" == document.location.hostname ||
         <li><a href="../search.html">search</a>|&nbsp;</li>
         <li><a href="#">examples</a>|&nbsp;</li>
         <li><a href="../gallery.html">gallery</a>|&nbsp;</li>
+        <li><a href="../citing.html">citation</a>|&nbsp;</li>
         <li><a href="../contents.html">docs</a> &raquo;</li>
  
       </ul>
@@ -625,6 +626,7 @@ if ("matplotlib.sourceforge.net" == document.location.hostname ||
         <li><a href="../search.html">search</a>|&nbsp;</li>
         <li><a href="#">examples</a>|&nbsp;</li>
         <li><a href="../gallery.html">gallery</a>|&nbsp;</li>
+        <li><a href="../citing.html">citation</a>|&nbsp;</li>
         <li><a href="../contents.html">docs</a> &raquo;</li>
  
       </ul>

--- a/gallery.html
+++ b/gallery.html
@@ -75,6 +75,7 @@ if ("matplotlib.sourceforge.net" == document.location.hostname ||
         <li><a href="search.html">search</a>|&nbsp;</li>
         <li><a href="examples/index.html">examples</a>|&nbsp;</li>
         <li><a href="#">gallery</a>|&nbsp;</li>
+        <li><a href="citing.html">citation</a>|&nbsp;</li>
         <li><a href="contents.html">docs</a> &raquo;</li>
  
       </ul>
@@ -971,6 +972,7 @@ if ("matplotlib.sourceforge.net" == document.location.hostname ||
         <li><a href="search.html">search</a>|&nbsp;</li>
         <li><a href="examples/index.html">examples</a>|&nbsp;</li>
         <li><a href="#">gallery</a>|&nbsp;</li>
+        <li><a href="citing.html">citation</a>|&nbsp;</li>
         <li><a href="contents.html">docs</a> &raquo;</li>
  
       </ul>

--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@ if ("matplotlib.sourceforge.net" == document.location.hostname ||
         <li><a href="search.html">search</a>|&nbsp;</li>
         <li><a href="examples/index.html">examples</a>|&nbsp;</li>
         <li><a href="gallery.html">gallery</a>|&nbsp;</li>
+        <li><a href="citing.html">citation</a>|&nbsp;</li>
         <li><a href="contents.html">docs</a> &raquo;</li>
  
       </ul>
@@ -267,6 +268,18 @@ and mapping toolkit
 <a href="http://matplotlib.github.com/basemap">basemap</a>, 3d plotting with <a href="mpl_toolkits/mplot3d/index.html">mplot3d</a>, axes and axis helpers in <a href="mpl_toolkits/axes_grid/index.html">axes_grid</a> and more.
  </p>
 
+<h1>Citing matplotlib</h1>
+
+<p>
+  matplotlib is the brainchild of John Hunter (1968-2012), who has put an
+  inordinate amount of effort into producing a piece of software utilized by
+  thousands of scientists worldwide.
+
+  If matplotlib contributes to a project that leads to a scientific publication,
+  please acknowledge this fact by citing the project. You can use this
+  <a href="citing.html">ready-made citation entry</a>.
+</p>
+
   <h1>Open source</h1>
 
 <p>Please
@@ -313,6 +326,7 @@ Mathematica is a registered trademark of Wolfram Research, Inc.
         <li><a href="search.html">search</a>|&nbsp;</li>
         <li><a href="examples/index.html">examples</a>|&nbsp;</li>
         <li><a href="gallery.html">gallery</a>|&nbsp;</li>
+        <li><a href="citing.html">citation</a>|&nbsp;</li>
         <li><a href="contents.html">docs</a> &raquo;</li>
  
       </ul>

--- a/search.html
+++ b/search.html
@@ -76,6 +76,7 @@ if ("matplotlib.sourceforge.net" == document.location.hostname ||
         <li><a href="#">search</a>|&nbsp;</li>
         <li><a href="examples/index.html">examples</a>|&nbsp;</li>
         <li><a href="gallery.html">gallery</a>|&nbsp;</li>
+        <li><a href="citing.html">citation</a>|&nbsp;</li>
         <li><a href="contents.html">docs</a> &raquo;</li>
  
       </ul>
@@ -130,6 +131,7 @@ if ("matplotlib.sourceforge.net" == document.location.hostname ||
         <li><a href="#">search</a>|&nbsp;</li>
         <li><a href="examples/index.html">examples</a>|&nbsp;</li>
         <li><a href="gallery.html">gallery</a>|&nbsp;</li>
+        <li><a href="citing.html">citation</a>|&nbsp;</li>
         <li><a href="contents.html">docs</a> &raquo;</li>
  
       </ul>


### PR DESCRIPTION
Does what it says on the tin. I fluffed up earlier and accidentally committed to the repository (0ec706f385a8f221703bc8b0785b44e4c10d3e21) using github's interactive editing feature (I wanted to add this without cloning the whole site because it's big). I reverted my fluff (19c7998b005fbf240f8256692785c02f47402c2a) and made this PR so we have a paper trail of contributions.

Sorry for any confusion.

Please give feedback on what I've written. I am writing a paper and wanted to reference matplotlib in it since all my figures were produced with matplotlib. I realised we hadn't actually added the citation stuff to the site. I shamelessly stole the ideas/layout from @fperez.

Thanks.
