### PR TITLE
FIX: add dumb banner to everything in examples/

### DIFF
--- a/examples/animation/animate_decay.html
+++ b/examples/animation/animate_decay.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/basic_example.html
+++ b/examples/animation/basic_example.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/basic_example_writer.html
+++ b/examples/animation/basic_example_writer.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/bayes_update.html
+++ b/examples/animation/bayes_update.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/double_pendulum_animated.html
+++ b/examples/animation/double_pendulum_animated.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/dynamic_image.html
+++ b/examples/animation/dynamic_image.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/dynamic_image2.html
+++ b/examples/animation/dynamic_image2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/histogram.html
+++ b/examples/animation/histogram.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/index.html
+++ b/examples/animation/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/moviewriter.html
+++ b/examples/animation/moviewriter.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/rain.html
+++ b/examples/animation/rain.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/random_data.html
+++ b/examples/animation/random_data.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/simple_3danim.html
+++ b/examples/animation/simple_3danim.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/simple_anim.html
+++ b/examples/animation/simple_anim.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/strip_chart_demo.html
+++ b/examples/animation/strip_chart_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/subplots.html
+++ b/examples/animation/subplots.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/animation/unchained.html
+++ b/examples/animation/unchained.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/agg_oo.html
+++ b/examples/api/agg_oo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/barchart_demo.html
+++ b/examples/api/barchart_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/bbox_intersect.html
+++ b/examples/api/bbox_intersect.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/collections_demo.html
+++ b/examples/api/collections_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/colorbar_basics.html
+++ b/examples/api/colorbar_basics.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/colorbar_only.html
+++ b/examples/api/colorbar_only.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/compound_path.html
+++ b/examples/api/compound_path.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/custom_projection_example.html
+++ b/examples/api/custom_projection_example.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/custom_scale_example.html
+++ b/examples/api/custom_scale_example.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/date_demo.html
+++ b/examples/api/date_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/date_index_formatter.html
+++ b/examples/api/date_index_formatter.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/demo_affine_image.html
+++ b/examples/api/demo_affine_image.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/donut_demo.html
+++ b/examples/api/donut_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/engineering_formatter.html
+++ b/examples/api/engineering_formatter.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/filled_step.html
+++ b/examples/api/filled_step.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/font_family_rc.html
+++ b/examples/api/font_family_rc.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/font_file.html
+++ b/examples/api/font_file.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/histogram_path_demo.html
+++ b/examples/api/histogram_path_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/image_zcoord.html
+++ b/examples/api/image_zcoord.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/index.html
+++ b/examples/api/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/joinstyle.html
+++ b/examples/api/joinstyle.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/legend_demo.html
+++ b/examples/api/legend_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/line_with_text.html
+++ b/examples/api/line_with_text.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/logo2.html
+++ b/examples/api/logo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/mathtext_asarray.html
+++ b/examples/api/mathtext_asarray.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/patch_collection.html
+++ b/examples/api/patch_collection.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/power_norm_demo.html
+++ b/examples/api/power_norm_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/quad_bezier.html
+++ b/examples/api/quad_bezier.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/radar_chart.html
+++ b/examples/api/radar_chart.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/sankey_demo_basics.html
+++ b/examples/api/sankey_demo_basics.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/sankey_demo_links.html
+++ b/examples/api/sankey_demo_links.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/sankey_demo_old.html
+++ b/examples/api/sankey_demo_old.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/sankey_demo_rankine.html
+++ b/examples/api/sankey_demo_rankine.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/scatter_piecharts.html
+++ b/examples/api/scatter_piecharts.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/skewt.html
+++ b/examples/api/skewt.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/span_regions.html
+++ b/examples/api/span_regions.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/two_scales.html
+++ b/examples/api/two_scales.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/unicode_minus.html
+++ b/examples/api/unicode_minus.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/watermark_image.html
+++ b/examples/api/watermark_image.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/api/watermark_text.html
+++ b/examples/api/watermark_text.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_axes_divider.html
+++ b/examples/axes_grid/demo_axes_divider.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_axes_grid.html
+++ b/examples/axes_grid/demo_axes_grid.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_axes_grid2.html
+++ b/examples/axes_grid/demo_axes_grid2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_axes_hbox_divider.html
+++ b/examples/axes_grid/demo_axes_hbox_divider.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_axes_rgb.html
+++ b/examples/axes_grid/demo_axes_rgb.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_axisline_style.html
+++ b/examples/axes_grid/demo_axisline_style.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_colorbar_with_inset_locator.html
+++ b/examples/axes_grid/demo_colorbar_with_inset_locator.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_curvelinear_grid.html
+++ b/examples/axes_grid/demo_curvelinear_grid.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_curvelinear_grid2.html
+++ b/examples/axes_grid/demo_curvelinear_grid2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_edge_colorbar.html
+++ b/examples/axes_grid/demo_edge_colorbar.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_floating_axes.html
+++ b/examples/axes_grid/demo_floating_axes.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_floating_axis.html
+++ b/examples/axes_grid/demo_floating_axis.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_imagegrid_aspect.html
+++ b/examples/axes_grid/demo_imagegrid_aspect.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/demo_parasite_axes2.html
+++ b/examples/axes_grid/demo_parasite_axes2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/index.html
+++ b/examples/axes_grid/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/inset_locator_demo.html
+++ b/examples/axes_grid/inset_locator_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/inset_locator_demo2.html
+++ b/examples/axes_grid/inset_locator_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/make_room_for_ylabel_using_axesgrid.html
+++ b/examples/axes_grid/make_room_for_ylabel_using_axesgrid.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/parasite_simple2.html
+++ b/examples/axes_grid/parasite_simple2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/scatter_hist.html
+++ b/examples/axes_grid/scatter_hist.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/simple_anchored_artists.html
+++ b/examples/axes_grid/simple_anchored_artists.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/simple_axesgrid.html
+++ b/examples/axes_grid/simple_axesgrid.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/simple_axesgrid2.html
+++ b/examples/axes_grid/simple_axesgrid2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/axes_grid/simple_axisline4.html
+++ b/examples/axes_grid/simple_axisline4.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/color/color_cycle_default.html
+++ b/examples/color/color_cycle_default.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/color/color_cycle_demo.html
+++ b/examples/color/color_cycle_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/color/colormaps_reference.html
+++ b/examples/color/colormaps_reference.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/color/index.html
+++ b/examples/color/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/color/named_colors.html
+++ b/examples/color/named_colors.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/close_event.html
+++ b/examples/event_handling/close_event.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/data_browser.html
+++ b/examples/event_handling/data_browser.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/figure_axes_enter_leave.html
+++ b/examples/event_handling/figure_axes_enter_leave.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/idle_and_timeout.html
+++ b/examples/event_handling/idle_and_timeout.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/index.html
+++ b/examples/event_handling/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/keypress_demo.html
+++ b/examples/event_handling/keypress_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/lasso_demo.html
+++ b/examples/event_handling/lasso_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/legend_picking.html
+++ b/examples/event_handling/legend_picking.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/looking_glass.html
+++ b/examples/event_handling/looking_glass.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/path_editor.html
+++ b/examples/event_handling/path_editor.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/pick_event_demo.html
+++ b/examples/event_handling/pick_event_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/pick_event_demo2.html
+++ b/examples/event_handling/pick_event_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/pipong.html
+++ b/examples/event_handling/pipong.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/poly_editor.html
+++ b/examples/event_handling/poly_editor.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/pong_gtk.html
+++ b/examples/event_handling/pong_gtk.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/resample.html
+++ b/examples/event_handling/resample.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/test_mouseclicks.html
+++ b/examples/event_handling/test_mouseclicks.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/timers.html
+++ b/examples/event_handling/timers.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/trifinder_event_demo.html
+++ b/examples/event_handling/trifinder_event_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/viewlims.html
+++ b/examples/event_handling/viewlims.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/event_handling/zoom_window.html
+++ b/examples/event_handling/zoom_window.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/frontpage/index.html
+++ b/examples/frontpage/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/frontpage/plot_3D.html
+++ b/examples/frontpage/plot_3D.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/frontpage/plot_contour.html
+++ b/examples/frontpage/plot_contour.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/frontpage/plot_histogram.html
+++ b/examples/frontpage/plot_histogram.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/frontpage/plot_membrane.html
+++ b/examples/frontpage/plot_membrane.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/images_contours_and_fields/contourf_log.html
+++ b/examples/images_contours_and_fields/contourf_log.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/images_contours_and_fields/image_demo.html
+++ b/examples/images_contours_and_fields/image_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/images_contours_and_fields/image_demo_clip_path.html
+++ b/examples/images_contours_and_fields/image_demo_clip_path.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/images_contours_and_fields/index.html
+++ b/examples/images_contours_and_fields/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/images_contours_and_fields/interpolation_methods.html
+++ b/examples/images_contours_and_fields/interpolation_methods.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/images_contours_and_fields/interpolation_none_vs_nearest.html
+++ b/examples/images_contours_and_fields/interpolation_none_vs_nearest.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/images_contours_and_fields/pcolormesh_levels.html
+++ b/examples/images_contours_and_fields/pcolormesh_levels.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/images_contours_and_fields/streamplot_demo_features.html
+++ b/examples/images_contours_and_fields/streamplot_demo_features.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/images_contours_and_fields/streamplot_demo_masking.html
+++ b/examples/images_contours_and_fields/streamplot_demo_masking.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/images_contours_and_fields/streamplot_demo_start_points.html
+++ b/examples/images_contours_and_fields/streamplot_demo_start_points.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/lines_bars_and_markers/barh_demo.html
+++ b/examples/lines_bars_and_markers/barh_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/lines_bars_and_markers/fill_demo.html
+++ b/examples/lines_bars_and_markers/fill_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/lines_bars_and_markers/fill_demo_features.html
+++ b/examples/lines_bars_and_markers/fill_demo_features.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/lines_bars_and_markers/index.html
+++ b/examples/lines_bars_and_markers/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/lines_bars_and_markers/line_demo_dash_control.html
+++ b/examples/lines_bars_and_markers/line_demo_dash_control.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/lines_bars_and_markers/line_styles_reference.html
+++ b/examples/lines_bars_and_markers/line_styles_reference.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/lines_bars_and_markers/linestyles.html
+++ b/examples/lines_bars_and_markers/linestyles.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/lines_bars_and_markers/marker_fillstyle_reference.html
+++ b/examples/lines_bars_and_markers/marker_fillstyle_reference.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/lines_bars_and_markers/marker_reference.html
+++ b/examples/lines_bars_and_markers/marker_reference.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/lines_bars_and_markers/scatter_with_legend.html
+++ b/examples/lines_bars_and_markers/scatter_with_legend.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/contour_manual.html
+++ b/examples/misc/contour_manual.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/font_indexing.html
+++ b/examples/misc/font_indexing.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/ftface_props.html
+++ b/examples/misc/ftface_props.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/image_thumbnail.html
+++ b/examples/misc/image_thumbnail.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/index.html
+++ b/examples/misc/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/longshort.html
+++ b/examples/misc/longshort.html
@@ -37,6 +37,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
     <div class="alert" style="background-color: #FEA46C; padding: 10px 0;
 ">
 <h2>Matplotlib 2.0.0rc2 is available</h2>

--- a/examples/misc/multiprocess.html
+++ b/examples/misc/multiprocess.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/rasterization_demo.html
+++ b/examples/misc/rasterization_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/rc_traits.html
+++ b/examples/misc/rc_traits.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/rec_groupby_demo.html
+++ b/examples/misc/rec_groupby_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/rec_join_demo.html
+++ b/examples/misc/rec_join_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/sample_data_demo.html
+++ b/examples/misc/sample_data_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/svg_filter_line.html
+++ b/examples/misc/svg_filter_line.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/svg_filter_pie.html
+++ b/examples/misc/svg_filter_pie.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/misc/tight_bbox_test.html
+++ b/examples/misc/tight_bbox_test.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/2dcollections3d_demo.html
+++ b/examples/mplot3d/2dcollections3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/bars3d_demo.html
+++ b/examples/mplot3d/bars3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/contour3d_demo.html
+++ b/examples/mplot3d/contour3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/contour3d_demo2.html
+++ b/examples/mplot3d/contour3d_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/contour3d_demo3.html
+++ b/examples/mplot3d/contour3d_demo3.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/contourf3d_demo.html
+++ b/examples/mplot3d/contourf3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/contourf3d_demo2.html
+++ b/examples/mplot3d/contourf3d_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/custom_shaded_3d_surface.html
+++ b/examples/mplot3d/custom_shaded_3d_surface.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/hist3d_demo.html
+++ b/examples/mplot3d/hist3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/index.html
+++ b/examples/mplot3d/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/lines3d_demo.html
+++ b/examples/mplot3d/lines3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/lorenz_attractor.html
+++ b/examples/mplot3d/lorenz_attractor.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/mixed_subplots_demo.html
+++ b/examples/mplot3d/mixed_subplots_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/offset_demo.html
+++ b/examples/mplot3d/offset_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/pathpatch3d_demo.html
+++ b/examples/mplot3d/pathpatch3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/polys3d_demo.html
+++ b/examples/mplot3d/polys3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/quiver3d_demo.html
+++ b/examples/mplot3d/quiver3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/rotate_axes3d_demo.html
+++ b/examples/mplot3d/rotate_axes3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/scatter3d_demo.html
+++ b/examples/mplot3d/scatter3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/subplot3d_demo.html
+++ b/examples/mplot3d/subplot3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/surface3d_demo.html
+++ b/examples/mplot3d/surface3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/surface3d_demo2.html
+++ b/examples/mplot3d/surface3d_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/surface3d_demo3.html
+++ b/examples/mplot3d/surface3d_demo3.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/surface3d_radial_demo.html
+++ b/examples/mplot3d/surface3d_radial_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/text3d_demo.html
+++ b/examples/mplot3d/text3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/tricontour3d_demo.html
+++ b/examples/mplot3d/tricontour3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/tricontourf3d_demo.html
+++ b/examples/mplot3d/tricontourf3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/trisurf3d_demo.html
+++ b/examples/mplot3d/trisurf3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/trisurf3d_demo2.html
+++ b/examples/mplot3d/trisurf3d_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/wire3d_animation_demo.html
+++ b/examples/mplot3d/wire3d_animation_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/wire3d_demo.html
+++ b/examples/mplot3d/wire3d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/mplot3d/wire3d_zero_stride.html
+++ b/examples/mplot3d/wire3d_zero_stride.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pie_and_polar_charts/index.html
+++ b/examples/pie_and_polar_charts/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pie_and_polar_charts/pie_demo_features.html
+++ b/examples/pie_and_polar_charts/pie_demo_features.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pie_and_polar_charts/polar_bar_demo.html
+++ b/examples/pie_and_polar_charts/polar_bar_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pie_and_polar_charts/polar_scatter_demo.html
+++ b/examples/pie_and_polar_charts/polar_scatter_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/accented_text.html
+++ b/examples/pylab_examples/accented_text.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/agg_buffer.html
+++ b/examples/pylab_examples/agg_buffer.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/agg_buffer_to_array.html
+++ b/examples/pylab_examples/agg_buffer_to_array.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/alignment_test.html
+++ b/examples/pylab_examples/alignment_test.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/anchored_artists.html
+++ b/examples/pylab_examples/anchored_artists.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/animation_demo.html
+++ b/examples/pylab_examples/animation_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/annotation_demo.html
+++ b/examples/pylab_examples/annotation_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/annotation_demo2.html
+++ b/examples/pylab_examples/annotation_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/annotation_demo3.html
+++ b/examples/pylab_examples/annotation_demo3.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/anscombe.html
+++ b/examples/pylab_examples/anscombe.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/arctest.html
+++ b/examples/pylab_examples/arctest.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/arrow_demo.html
+++ b/examples/pylab_examples/arrow_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/arrow_simple_demo.html
+++ b/examples/pylab_examples/arrow_simple_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/aspect_loglog.html
+++ b/examples/pylab_examples/aspect_loglog.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/axes_demo.html
+++ b/examples/pylab_examples/axes_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/axes_props.html
+++ b/examples/pylab_examples/axes_props.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/axes_zoom_effect.html
+++ b/examples/pylab_examples/axes_zoom_effect.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/axhspan_demo.html
+++ b/examples/pylab_examples/axhspan_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/axis_equal_demo.html
+++ b/examples/pylab_examples/axis_equal_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/bar_stacked.html
+++ b/examples/pylab_examples/bar_stacked.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/barb_demo.html
+++ b/examples/pylab_examples/barb_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/barchart_demo.html
+++ b/examples/pylab_examples/barchart_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/barchart_demo2.html
+++ b/examples/pylab_examples/barchart_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/barcode_demo.html
+++ b/examples/pylab_examples/barcode_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/boxplot_demo.html
+++ b/examples/pylab_examples/boxplot_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/boxplot_demo2.html
+++ b/examples/pylab_examples/boxplot_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/boxplot_demo3.html
+++ b/examples/pylab_examples/boxplot_demo3.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/break.html
+++ b/examples/pylab_examples/break.html
@@ -37,6 +37,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
     <div class="alert" style="background-color: #FEA46C; padding: 10px 0;
 ">
 <h2>Matplotlib 2.0.0rc2 is available</h2>

--- a/examples/pylab_examples/broken_axis.html
+++ b/examples/pylab_examples/broken_axis.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/broken_barh.html
+++ b/examples/pylab_examples/broken_barh.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/centered_ticklabels.html
+++ b/examples/pylab_examples/centered_ticklabels.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/cohere_demo.html
+++ b/examples/pylab_examples/cohere_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/color_by_yvalue.html
+++ b/examples/pylab_examples/color_by_yvalue.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/color_demo.html
+++ b/examples/pylab_examples/color_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/colorbar_tick_labelling_demo.html
+++ b/examples/pylab_examples/colorbar_tick_labelling_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/colours.html
+++ b/examples/pylab_examples/colours.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/contour_corner_mask.html
+++ b/examples/pylab_examples/contour_corner_mask.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/contour_demo.html
+++ b/examples/pylab_examples/contour_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/contour_image.html
+++ b/examples/pylab_examples/contour_image.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/contour_label_demo.html
+++ b/examples/pylab_examples/contour_label_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/contourf_demo.html
+++ b/examples/pylab_examples/contourf_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/contourf_hatching.html
+++ b/examples/pylab_examples/contourf_hatching.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/coords_demo.html
+++ b/examples/pylab_examples/coords_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/coords_report.html
+++ b/examples/pylab_examples/coords_report.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/csd_demo.html
+++ b/examples/pylab_examples/csd_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/cursor_demo.html
+++ b/examples/pylab_examples/cursor_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/custom_cmap.html
+++ b/examples/pylab_examples/custom_cmap.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/custom_figure_class.html
+++ b/examples/pylab_examples/custom_figure_class.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/custom_ticker1.html
+++ b/examples/pylab_examples/custom_ticker1.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/customize_rc.html
+++ b/examples/pylab_examples/customize_rc.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/dashpointlabel.html
+++ b/examples/pylab_examples/dashpointlabel.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/data_helper.html
+++ b/examples/pylab_examples/data_helper.html
@@ -37,6 +37,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
     <div class="alert" style="background-color: #FEA46C; padding: 10px 0;
 ">
 <h2>Matplotlib 2.0.0rc2 is available</h2>

--- a/examples/pylab_examples/date_demo1.html
+++ b/examples/pylab_examples/date_demo1.html
@@ -37,6 +37,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
     <div class="alert" style="background-color: #FEA46C; padding: 10px 0;
 ">
 <h2>Matplotlib 2.0.0rc2 is available</h2>

--- a/examples/pylab_examples/date_demo2.html
+++ b/examples/pylab_examples/date_demo2.html
@@ -37,6 +37,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
     <div class="alert" style="background-color: #FEA46C; padding: 10px 0;
 ">
 <h2>Matplotlib 2.0.0rc2 is available</h2>

--- a/examples/pylab_examples/date_demo_convert.html
+++ b/examples/pylab_examples/date_demo_convert.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/date_demo_rrule.html
+++ b/examples/pylab_examples/date_demo_rrule.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/date_index_formatter.html
+++ b/examples/pylab_examples/date_index_formatter.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/demo_agg_filter.html
+++ b/examples/pylab_examples/demo_agg_filter.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/demo_annotation_box.html
+++ b/examples/pylab_examples/demo_annotation_box.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/demo_bboximage.html
+++ b/examples/pylab_examples/demo_bboximage.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/demo_ribbon_box.html
+++ b/examples/pylab_examples/demo_ribbon_box.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/demo_text_path.html
+++ b/examples/pylab_examples/demo_text_path.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/demo_text_rotation_mode.html
+++ b/examples/pylab_examples/demo_text_rotation_mode.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/demo_tight_layout.html
+++ b/examples/pylab_examples/demo_tight_layout.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/dolphin.html
+++ b/examples/pylab_examples/dolphin.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/ellipse_collection.html
+++ b/examples/pylab_examples/ellipse_collection.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/ellipse_demo.html
+++ b/examples/pylab_examples/ellipse_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/ellipse_rotated.html
+++ b/examples/pylab_examples/ellipse_rotated.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/equal_aspect_ratio.html
+++ b/examples/pylab_examples/equal_aspect_ratio.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/errorbar_limits.html
+++ b/examples/pylab_examples/errorbar_limits.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/errorbar_subsample.html
+++ b/examples/pylab_examples/errorbar_subsample.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/eventcollection_demo.html
+++ b/examples/pylab_examples/eventcollection_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/eventplot_demo.html
+++ b/examples/pylab_examples/eventplot_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/fancyarrow_demo.html
+++ b/examples/pylab_examples/fancyarrow_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/fancybox_demo.html
+++ b/examples/pylab_examples/fancybox_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/fancybox_demo2.html
+++ b/examples/pylab_examples/fancybox_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/fancytextbox_demo.html
+++ b/examples/pylab_examples/fancytextbox_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/figimage_demo.html
+++ b/examples/pylab_examples/figimage_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/figlegend_demo.html
+++ b/examples/pylab_examples/figlegend_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/figure_title.html
+++ b/examples/pylab_examples/figure_title.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/fill_between_demo.html
+++ b/examples/pylab_examples/fill_between_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/fill_betweenx_demo.html
+++ b/examples/pylab_examples/fill_betweenx_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/fill_spiral.html
+++ b/examples/pylab_examples/fill_spiral.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/finance_demo.html
+++ b/examples/pylab_examples/finance_demo.html
@@ -37,6 +37,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
     <div class="alert" style="background-color: #FEA46C; padding: 10px 0;
 ">
 <h2>Matplotlib 2.0.0rc2 is available</h2>

--- a/examples/pylab_examples/finance_work2.html
+++ b/examples/pylab_examples/finance_work2.html
@@ -37,6 +37,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
     <div class="alert" style="background-color: #FEA46C; padding: 10px 0;
 ">
 <h2>Matplotlib 2.0.0rc2 is available</h2>

--- a/examples/pylab_examples/findobj_demo.html
+++ b/examples/pylab_examples/findobj_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/font_table_ttf.html
+++ b/examples/pylab_examples/font_table_ttf.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/fonts_demo.html
+++ b/examples/pylab_examples/fonts_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/fonts_demo_kw.html
+++ b/examples/pylab_examples/fonts_demo_kw.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/ganged_plots.html
+++ b/examples/pylab_examples/ganged_plots.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/geo_demo.html
+++ b/examples/pylab_examples/geo_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/ginput_demo.html
+++ b/examples/pylab_examples/ginput_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/ginput_manual_clabel.html
+++ b/examples/pylab_examples/ginput_manual_clabel.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/gradient_bar.html
+++ b/examples/pylab_examples/gradient_bar.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/griddata_demo.html
+++ b/examples/pylab_examples/griddata_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/hatch_demo.html
+++ b/examples/pylab_examples/hatch_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/hexbin_demo.html
+++ b/examples/pylab_examples/hexbin_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/hexbin_demo2.html
+++ b/examples/pylab_examples/hexbin_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/hist2d_demo.html
+++ b/examples/pylab_examples/hist2d_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/hist2d_log_demo.html
+++ b/examples/pylab_examples/hist2d_log_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/hist_colormapped.html
+++ b/examples/pylab_examples/hist_colormapped.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/histogram_percent_demo.html
+++ b/examples/pylab_examples/histogram_percent_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/hyperlinks.html
+++ b/examples/pylab_examples/hyperlinks.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/image_clip_path.html
+++ b/examples/pylab_examples/image_clip_path.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/image_demo.html
+++ b/examples/pylab_examples/image_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/image_demo2.html
+++ b/examples/pylab_examples/image_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/image_interp.html
+++ b/examples/pylab_examples/image_interp.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/image_masked.html
+++ b/examples/pylab_examples/image_masked.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/image_nonuniform.html
+++ b/examples/pylab_examples/image_nonuniform.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/image_origin.html
+++ b/examples/pylab_examples/image_origin.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/image_slices_viewer.html
+++ b/examples/pylab_examples/image_slices_viewer.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/index.html
+++ b/examples/pylab_examples/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/interp_demo.html
+++ b/examples/pylab_examples/interp_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/invert_axes.html
+++ b/examples/pylab_examples/invert_axes.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/layer_images.html
+++ b/examples/pylab_examples/layer_images.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/leftventricle_bulleye.html
+++ b/examples/pylab_examples/leftventricle_bulleye.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/legend_demo2.html
+++ b/examples/pylab_examples/legend_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/legend_demo3.html
+++ b/examples/pylab_examples/legend_demo3.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/legend_demo4.html
+++ b/examples/pylab_examples/legend_demo4.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/legend_demo5.html
+++ b/examples/pylab_examples/legend_demo5.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/line_collection.html
+++ b/examples/pylab_examples/line_collection.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/line_collection2.html
+++ b/examples/pylab_examples/line_collection2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/load_converter.html
+++ b/examples/pylab_examples/load_converter.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/loadrec.html
+++ b/examples/pylab_examples/loadrec.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/log_bar.html
+++ b/examples/pylab_examples/log_bar.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/log_demo.html
+++ b/examples/pylab_examples/log_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/log_test.html
+++ b/examples/pylab_examples/log_test.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/logo.html
+++ b/examples/pylab_examples/logo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/major_minor_demo1.html
+++ b/examples/pylab_examples/major_minor_demo1.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/major_minor_demo2.html
+++ b/examples/pylab_examples/major_minor_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/manual_axis.html
+++ b/examples/pylab_examples/manual_axis.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/marker_path.html
+++ b/examples/pylab_examples/marker_path.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/markevery_demo.html
+++ b/examples/pylab_examples/markevery_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/masked_demo.html
+++ b/examples/pylab_examples/masked_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/mathtext_demo.html
+++ b/examples/pylab_examples/mathtext_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/mathtext_examples.html
+++ b/examples/pylab_examples/mathtext_examples.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/matplotlib_icon.html
+++ b/examples/pylab_examples/matplotlib_icon.html
@@ -37,6 +37,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
     <div class="alert" style="background-color: #FEA46C; padding: 10px 0;
 ">
 <h2>Matplotlib 2.0.0rc2 is available</h2>

--- a/examples/pylab_examples/matshow.html
+++ b/examples/pylab_examples/matshow.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/movie_demo.html
+++ b/examples/pylab_examples/movie_demo.html
@@ -37,6 +37,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
     <div class="alert" style="background-color: #FEA46C; padding: 10px 0;
 ">
 <h2>Matplotlib 2.0.0rc2 is available</h2>

--- a/examples/pylab_examples/mri_demo.html
+++ b/examples/pylab_examples/mri_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/mri_with_eeg.html
+++ b/examples/pylab_examples/mri_with_eeg.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/multi_image.html
+++ b/examples/pylab_examples/multi_image.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/multicolored_line.html
+++ b/examples/pylab_examples/multicolored_line.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/multiline.html
+++ b/examples/pylab_examples/multiline.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/multipage_pdf.html
+++ b/examples/pylab_examples/multipage_pdf.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/multiple_figs_demo.html
+++ b/examples/pylab_examples/multiple_figs_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/multiple_yaxis_with_spines.html
+++ b/examples/pylab_examples/multiple_yaxis_with_spines.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/nan_test.html
+++ b/examples/pylab_examples/nan_test.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/newscalarformatter_demo.html
+++ b/examples/pylab_examples/newscalarformatter_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/patheffect_demo.html
+++ b/examples/pylab_examples/patheffect_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/pcolor_demo.html
+++ b/examples/pylab_examples/pcolor_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/pcolor_log.html
+++ b/examples/pylab_examples/pcolor_log.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/pcolor_small.html
+++ b/examples/pylab_examples/pcolor_small.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/pie_demo2.html
+++ b/examples/pylab_examples/pie_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/plotfile_demo.html
+++ b/examples/pylab_examples/plotfile_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/polar_demo.html
+++ b/examples/pylab_examples/polar_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/polar_legend.html
+++ b/examples/pylab_examples/polar_legend.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/print_stdout.html
+++ b/examples/pylab_examples/print_stdout.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/psd_demo.html
+++ b/examples/pylab_examples/psd_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/psd_demo2.html
+++ b/examples/pylab_examples/psd_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/psd_demo3.html
+++ b/examples/pylab_examples/psd_demo3.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/psd_demo_complex.html
+++ b/examples/pylab_examples/psd_demo_complex.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/pythonic_matplotlib.html
+++ b/examples/pylab_examples/pythonic_matplotlib.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/quadmesh_demo.html
+++ b/examples/pylab_examples/quadmesh_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/quiver_demo.html
+++ b/examples/pylab_examples/quiver_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/quiver_simple_demo.html
+++ b/examples/pylab_examples/quiver_simple_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/scatter_custom_symbol.html
+++ b/examples/pylab_examples/scatter_custom_symbol.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/scatter_demo2.html
+++ b/examples/pylab_examples/scatter_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/scatter_hist.html
+++ b/examples/pylab_examples/scatter_hist.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/scatter_masked.html
+++ b/examples/pylab_examples/scatter_masked.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/scatter_profile.html
+++ b/examples/pylab_examples/scatter_profile.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/scatter_star_poly.html
+++ b/examples/pylab_examples/scatter_star_poly.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/scatter_symbol.html
+++ b/examples/pylab_examples/scatter_symbol.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/set_and_get.html
+++ b/examples/pylab_examples/set_and_get.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/shading_example.html
+++ b/examples/pylab_examples/shading_example.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/shared_axis_across_figures.html
+++ b/examples/pylab_examples/shared_axis_across_figures.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/shared_axis_demo.html
+++ b/examples/pylab_examples/shared_axis_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/simple_plot.html
+++ b/examples/pylab_examples/simple_plot.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/simple_plot_fps.html
+++ b/examples/pylab_examples/simple_plot_fps.html
@@ -37,6 +37,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
     <div class="alert" style="background-color: #FEA46C; padding: 10px 0;
 ">
 <h3>We're updating the default styles for Matplotlib 2.0</h3>

--- a/examples/pylab_examples/specgram_demo.html
+++ b/examples/pylab_examples/specgram_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/spectrum_demo.html
+++ b/examples/pylab_examples/spectrum_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/spine_placement_demo.html
+++ b/examples/pylab_examples/spine_placement_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/spy_demos.html
+++ b/examples/pylab_examples/spy_demos.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/stackplot_demo.html
+++ b/examples/pylab_examples/stackplot_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/stackplot_demo2.html
+++ b/examples/pylab_examples/stackplot_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/stem_plot.html
+++ b/examples/pylab_examples/stem_plot.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/step_demo.html
+++ b/examples/pylab_examples/step_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/stix_fonts_demo.html
+++ b/examples/pylab_examples/stix_fonts_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/stock_demo.html
+++ b/examples/pylab_examples/stock_demo.html
@@ -37,6 +37,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
     <div class="alert" style="background-color: #FEA46C; padding: 10px 0;
 ">
 <h2>Matplotlib 2.0.0rc2 is available</h2>

--- a/examples/pylab_examples/subplot_demo.html
+++ b/examples/pylab_examples/subplot_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/subplot_toolbar.html
+++ b/examples/pylab_examples/subplot_toolbar.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/subplots_adjust.html
+++ b/examples/pylab_examples/subplots_adjust.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/subplots_demo.html
+++ b/examples/pylab_examples/subplots_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/symlog_demo.html
+++ b/examples/pylab_examples/symlog_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/system_monitor.html
+++ b/examples/pylab_examples/system_monitor.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/table_demo.html
+++ b/examples/pylab_examples/table_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/tex_demo.html
+++ b/examples/pylab_examples/tex_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/tex_unicode_demo.html
+++ b/examples/pylab_examples/tex_unicode_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/text_handles.html
+++ b/examples/pylab_examples/text_handles.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/text_rotation.html
+++ b/examples/pylab_examples/text_rotation.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/text_rotation_relative_to_line.html
+++ b/examples/pylab_examples/text_rotation_relative_to_line.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/titles_demo.html
+++ b/examples/pylab_examples/titles_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/toggle_images.html
+++ b/examples/pylab_examples/toggle_images.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/transoffset.html
+++ b/examples/pylab_examples/transoffset.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/tricontour_demo.html
+++ b/examples/pylab_examples/tricontour_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/tricontour_smooth_delaunay.html
+++ b/examples/pylab_examples/tricontour_smooth_delaunay.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/tricontour_smooth_user.html
+++ b/examples/pylab_examples/tricontour_smooth_user.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/tricontour_vs_griddata.html
+++ b/examples/pylab_examples/tricontour_vs_griddata.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/trigradient_demo.html
+++ b/examples/pylab_examples/trigradient_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/triinterp_demo.html
+++ b/examples/pylab_examples/triinterp_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/tripcolor_demo.html
+++ b/examples/pylab_examples/tripcolor_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/triplot_demo.html
+++ b/examples/pylab_examples/triplot_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/usetex_baseline_test.html
+++ b/examples/pylab_examples/usetex_baseline_test.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/usetex_demo.html
+++ b/examples/pylab_examples/usetex_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/usetex_fonteffects.html
+++ b/examples/pylab_examples/usetex_fonteffects.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/vline_hline_demo.html
+++ b/examples/pylab_examples/vline_hline_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/webapp_demo.html
+++ b/examples/pylab_examples/webapp_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/xcorr_demo.html
+++ b/examples/pylab_examples/xcorr_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pylab_examples/zorder_demo.html
+++ b/examples/pylab_examples/zorder_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/align_ylabels.html
+++ b/examples/pyplots/align_ylabels.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/annotate_transform.html
+++ b/examples/pyplots/annotate_transform.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/annotation_basic.html
+++ b/examples/pyplots/annotation_basic.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/annotation_polar.html
+++ b/examples/pyplots/annotation_polar.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/auto_subplots_adjust.html
+++ b/examples/pyplots/auto_subplots_adjust.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/boxplot_demo.html
+++ b/examples/pyplots/boxplot_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/compound_path_demo.html
+++ b/examples/pyplots/compound_path_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/dollar_ticks.html
+++ b/examples/pyplots/dollar_ticks.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/fig_axes_customize_simple.html
+++ b/examples/pyplots/fig_axes_customize_simple.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/fig_axes_labels_simple.html
+++ b/examples/pyplots/fig_axes_labels_simple.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/fig_x.html
+++ b/examples/pyplots/fig_x.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/index.html
+++ b/examples/pyplots/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/pyplot_annotate.html
+++ b/examples/pyplots/pyplot_annotate.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/pyplot_formatstr.html
+++ b/examples/pyplots/pyplot_formatstr.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/pyplot_mathtext.html
+++ b/examples/pyplots/pyplot_mathtext.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/pyplot_scales.html
+++ b/examples/pyplots/pyplot_scales.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/pyplot_simple.html
+++ b/examples/pyplots/pyplot_simple.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/pyplot_text.html
+++ b/examples/pyplots/pyplot_text.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/pyplot_three.html
+++ b/examples/pyplots/pyplot_three.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/pyplot_two_subplots.html
+++ b/examples/pyplots/pyplot_two_subplots.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/tex_demo.html
+++ b/examples/pyplots/tex_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/text_commands.html
+++ b/examples/pyplots/text_commands.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/text_layout.html
+++ b/examples/pyplots/text_layout.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/whats_new_1_subplot3d.html
+++ b/examples/pyplots/whats_new_1_subplot3d.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/whats_new_98_4_fancy.html
+++ b/examples/pyplots/whats_new_98_4_fancy.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/whats_new_98_4_fill_between.html
+++ b/examples/pyplots/whats_new_98_4_fill_between.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/whats_new_98_4_legend.html
+++ b/examples/pyplots/whats_new_98_4_legend.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/whats_new_99_axes_grid.html
+++ b/examples/pyplots/whats_new_99_axes_grid.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/whats_new_99_mplot3d.html
+++ b/examples/pyplots/whats_new_99_mplot3d.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/pyplots/whats_new_99_spines.html
+++ b/examples/pyplots/whats_new_99_spines.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/scales/index.html
+++ b/examples/scales/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/scales/scales.html
+++ b/examples/scales/scales.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/shapes_and_collections/artist_reference.html
+++ b/examples/shapes_and_collections/artist_reference.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/shapes_and_collections/index.html
+++ b/examples/shapes_and_collections/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/shapes_and_collections/path_patch_demo.html
+++ b/examples/shapes_and_collections/path_patch_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/shapes_and_collections/scatter_demo.html
+++ b/examples/shapes_and_collections/scatter_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/showcase/anatomy.html
+++ b/examples/showcase/anatomy.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/showcase/bachelors_degrees_by_gender.html
+++ b/examples/showcase/bachelors_degrees_by_gender.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/showcase/firefox.html
+++ b/examples/showcase/firefox.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/showcase/index.html
+++ b/examples/showcase/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/showcase/integral_demo.html
+++ b/examples/showcase/integral_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/showcase/mandelbrot.html
+++ b/examples/showcase/mandelbrot.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/showcase/xkcd.html
+++ b/examples/showcase/xkcd.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/specialty_plots/advanced_hillshading.html
+++ b/examples/specialty_plots/advanced_hillshading.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/specialty_plots/hinton_demo.html
+++ b/examples/specialty_plots/hinton_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/specialty_plots/index.html
+++ b/examples/specialty_plots/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/specialty_plots/topographic_hillshading.html
+++ b/examples/specialty_plots/topographic_hillshading.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/boxplot_color_demo.html
+++ b/examples/statistics/boxplot_color_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/boxplot_demo.html
+++ b/examples/statistics/boxplot_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/boxplot_vs_violin_demo.html
+++ b/examples/statistics/boxplot_vs_violin_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/bxp_demo.html
+++ b/examples/statistics/bxp_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/customized_violin_demo.html
+++ b/examples/statistics/customized_violin_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/errorbar_demo.html
+++ b/examples/statistics/errorbar_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/errorbar_demo_features.html
+++ b/examples/statistics/errorbar_demo_features.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/errorbar_limits.html
+++ b/examples/statistics/errorbar_limits.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/errorbars_and_boxes.html
+++ b/examples/statistics/errorbars_and_boxes.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/histogram_demo_cumulative.html
+++ b/examples/statistics/histogram_demo_cumulative.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/histogram_demo_features.html
+++ b/examples/statistics/histogram_demo_features.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/histogram_demo_histtypes.html
+++ b/examples/statistics/histogram_demo_histtypes.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/histogram_demo_multihist.html
+++ b/examples/statistics/histogram_demo_multihist.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/index.html
+++ b/examples/statistics/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/multiple_histograms_side_by_side.html
+++ b/examples/statistics/multiple_histograms_side_by_side.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/statistics/violinplot_demo.html
+++ b/examples/statistics/violinplot_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/style_sheets/index.html
+++ b/examples/style_sheets/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/style_sheets/plot_bmh.html
+++ b/examples/style_sheets/plot_bmh.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/style_sheets/plot_dark_background.html
+++ b/examples/style_sheets/plot_dark_background.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/style_sheets/plot_fivethirtyeight.html
+++ b/examples/style_sheets/plot_fivethirtyeight.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/style_sheets/plot_ggplot.html
+++ b/examples/style_sheets/plot_ggplot.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/style_sheets/plot_grayscale.html
+++ b/examples/style_sheets/plot_grayscale.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/style_sheets/style_sheets_reference.html
+++ b/examples/style_sheets/style_sheets_reference.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/subplots_axes_and_figures/fahrenheit_celsius_scales.html
+++ b/examples/subplots_axes_and_figures/fahrenheit_celsius_scales.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/subplots_axes_and_figures/index.html
+++ b/examples/subplots_axes_and_figures/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/subplots_axes_and_figures/subplot_demo.html
+++ b/examples/subplots_axes_and_figures/subplot_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/tests/backend_driver.html
+++ b/examples/tests/backend_driver.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/tests/index.html
+++ b/examples/tests/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/text_labels_and_annotations/autowrap_demo.html
+++ b/examples/text_labels_and_annotations/autowrap_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/text_labels_and_annotations/index.html
+++ b/examples/text_labels_and_annotations/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/text_labels_and_annotations/rainbow_text.html
+++ b/examples/text_labels_and_annotations/rainbow_text.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/text_labels_and_annotations/text_demo_fontdict.html
+++ b/examples/text_labels_and_annotations/text_demo_fontdict.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/text_labels_and_annotations/unicode_demo.html
+++ b/examples/text_labels_and_annotations/unicode_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/ticks_and_spines/index.html
+++ b/examples/ticks_and_spines/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/ticks_and_spines/spines_demo.html
+++ b/examples/ticks_and_spines/spines_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/ticks_and_spines/spines_demo_bounds.html
+++ b/examples/ticks_and_spines/spines_demo_bounds.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/ticks_and_spines/spines_demo_dropped.html
+++ b/examples/ticks_and_spines/spines_demo_dropped.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/ticks_and_spines/tick-formatters.html
+++ b/examples/ticks_and_spines/tick-formatters.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/ticks_and_spines/tick-locators.html
+++ b/examples/ticks_and_spines/tick-locators.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/ticks_and_spines/tick_labels_from_values.html
+++ b/examples/ticks_and_spines/tick_labels_from_values.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/ticks_and_spines/ticklabels_demo_rotation.html
+++ b/examples/ticks_and_spines/ticklabels_demo_rotation.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/units/annotate_with_units.html
+++ b/examples/units/annotate_with_units.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/units/artist_tests.html
+++ b/examples/units/artist_tests.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/units/bar_demo2.html
+++ b/examples/units/bar_demo2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/units/bar_unit_demo.html
+++ b/examples/units/bar_unit_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/units/basic_units.html
+++ b/examples/units/basic_units.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/units/ellipse_with_units.html
+++ b/examples/units/ellipse_with_units.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/units/evans_test.html
+++ b/examples/units/evans_test.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/units/index.html
+++ b/examples/units/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/units/radian_demo.html
+++ b/examples/units/radian_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/units/units_sample.html
+++ b/examples/units/units_sample.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/units/units_scatter.html
+++ b/examples/units/units_scatter.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_gtk.html
+++ b/examples/user_interfaces/embedding_in_gtk.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_gtk2.html
+++ b/examples/user_interfaces/embedding_in_gtk2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_gtk3.html
+++ b/examples/user_interfaces/embedding_in_gtk3.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_gtk3_panzoom.html
+++ b/examples/user_interfaces/embedding_in_gtk3_panzoom.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_qt4.html
+++ b/examples/user_interfaces/embedding_in_qt4.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_qt4_wtoolbar.html
+++ b/examples/user_interfaces/embedding_in_qt4_wtoolbar.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_qt5.html
+++ b/examples/user_interfaces/embedding_in_qt5.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_tk.html
+++ b/examples/user_interfaces/embedding_in_tk.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_tk2.html
+++ b/examples/user_interfaces/embedding_in_tk2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_tk_canvas.html
+++ b/examples/user_interfaces/embedding_in_tk_canvas.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_wx2.html
+++ b/examples/user_interfaces/embedding_in_wx2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_wx3.html
+++ b/examples/user_interfaces/embedding_in_wx3.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_wx4.html
+++ b/examples/user_interfaces/embedding_in_wx4.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_in_wx5.html
+++ b/examples/user_interfaces/embedding_in_wx5.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/embedding_webagg.html
+++ b/examples/user_interfaces/embedding_webagg.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/fourier_demo_wx.html
+++ b/examples/user_interfaces/fourier_demo_wx.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/gtk_spreadsheet.html
+++ b/examples/user_interfaces/gtk_spreadsheet.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/histogram_demo_canvasagg.html
+++ b/examples/user_interfaces/histogram_demo_canvasagg.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/index.html
+++ b/examples/user_interfaces/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/interactive.html
+++ b/examples/user_interfaces/interactive.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/interactive2.html
+++ b/examples/user_interfaces/interactive2.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/lineprops_dialog_gtk.html
+++ b/examples/user_interfaces/lineprops_dialog_gtk.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/mathtext_wx.html
+++ b/examples/user_interfaces/mathtext_wx.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/mpl_with_glade.html
+++ b/examples/user_interfaces/mpl_with_glade.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/mpl_with_glade_316.html
+++ b/examples/user_interfaces/mpl_with_glade_316.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/pylab_with_gtk.html
+++ b/examples/user_interfaces/pylab_with_gtk.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/rec_edit_gtk_custom.html
+++ b/examples/user_interfaces/rec_edit_gtk_custom.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/rec_edit_gtk_simple.html
+++ b/examples/user_interfaces/rec_edit_gtk_simple.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/svg_histogram.html
+++ b/examples/user_interfaces/svg_histogram.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/svg_tooltip.html
+++ b/examples/user_interfaces/svg_tooltip.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/toolmanager.html
+++ b/examples/user_interfaces/toolmanager.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/user_interfaces/wxcursor_demo.html
+++ b/examples/user_interfaces/wxcursor_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/widgets/buttons.html
+++ b/examples/widgets/buttons.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/widgets/check_buttons.html
+++ b/examples/widgets/check_buttons.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/widgets/cursor.html
+++ b/examples/widgets/cursor.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/widgets/index.html
+++ b/examples/widgets/index.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/widgets/lasso_selector_demo.html
+++ b/examples/widgets/lasso_selector_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/widgets/menu.html
+++ b/examples/widgets/menu.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/widgets/multicursor.html
+++ b/examples/widgets/multicursor.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/widgets/radio_buttons.html
+++ b/examples/widgets/radio_buttons.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/widgets/rectangle_selector.html
+++ b/examples/widgets/rectangle_selector.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/widgets/slider_demo.html
+++ b/examples/widgets/slider_demo.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 

--- a/examples/widgets/span_selector.html
+++ b/examples/widgets/span_selector.html
@@ -42,6 +42,11 @@ type="text/css" />
 
   </head>
   <body>
+    <div id="unreleased-message">
+      You are reading documentation that no longer exists in the current
+      release of Matplotlib!
+    </div>
+         
 
 
 


### PR DESCRIPTION
There is a fancier version of this in the PR list, but this takes care of the worst offenders in `examples/`....

<img width="918" alt="boo" src="https://user-images.githubusercontent.com/1562854/53604065-3eef0480-3b68-11e9-8856-7dfe91054e07.png">
