### PR TITLE
Set canonical links for some of the most indexed pages.

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -38,7 +38,7 @@ type="text/css" />
     <link rel="next" title="animation Examples" href="animation/index.html" />
     <link rel="prev" title="Default Color changes" href="../devel/color_changes.html" /> 
 
-
+    <link rel="canonical" href="https://matplotlib.org/tutorials/introductory/pyplot.html" />
   </head>
   <body>
 

--- a/gallery.html
+++ b/gallery.html
@@ -35,8 +35,7 @@ type="text/css" />
     <link rel="search" title="Search" href="search.html"
 />
     <link rel="top" title="Matplotlib 2.0.2 documentation" href="index.html" /> 
-
-
+    <link rel="canonical" href="https://matplotlib.org/gallery/" />
   </head>
   <body>
 

--- a/users/pyplot_tutorial.html
+++ b/users/pyplot_tutorial.html
@@ -38,6 +38,7 @@ type="text/css" />
     <link rel="up" title="Tutorials" href="tutorials.html" />
     <link rel="next" title="Image tutorial" href="image_tutorial.html" />
     <link rel="prev" title="Tutorials" href="tutorials.html" /> 
+    <link rel="canonical" href="https://matplotlib.org/tutorials/introductory/pyplot.html" />
 
 
   </head>


### PR DESCRIPTION
When googling "matplotlib" or "matplotlib gallery" some of these pages
come in the first results (in incognito mode) but refer to old
matplotlib (2.0.2)

This should (hopefully) start to nudge SEO toward the newest page.