### PR TITLE
Fix do all redirects

### DIFF
--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -1,0 +1,203 @@
+import argparse
+import glob
+import logging
+import multiprocessing
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+
+"""
+This script does two things that improve the website organization.
+
+First, we used to host in the root of the webpage, but have now moved to
+``/stable/``.  We do not want obsolete links to link to nothing (or that has
+been our policy), so we currently just keep the old version at the top level.
+Here, instead, we either softlink to the newest version, or replace the file by
+an html refresh redirect.
+
+Second, it changes the canonical link in each html file to the newest version
+found of the html file (including stable if its in the latest version.)
+
+This script takes a while, and is destructive, so should probably be run on a
+branch and pushed as a PR so it can easily be reverted.
+"""
+
+_log = logging.getLogger('make_redirect_links')
+
+
+tocheck = ['stable'] + [f'{major}.{minor}.{micro}'
+                        for major in range(6, -1, -1)
+                        for minor in range(6, -1, -1)
+                        for micro in range(6, -1, -1)]
+
+toignore = tocheck + ['mpl-probscale', 'mpl_examples', 'mpl_toolkits',
+                      '_webpageutils', 'xkcd', 'sitemap.xml',
+                      'robots.txt', 'CNAME', '.git']
+
+logging.basicConfig(level=logging.DEBUG)
+
+
+def findlast(fname, tocheck):
+    """
+    Check the directories listed in ``tocheck`` to see if they have
+    ``fname`` in them.  Return the first one found, or None
+    """
+    p = pathlib.Path(fname)
+    for t in tocheck:
+        pnew = pathlib.Path(t, p)
+        if pnew.exists():
+            return t
+    else:
+        return None
+
+html_redirect = """
+<!DOCTYPE HTML>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="refresh" content="0;url=https://matplotlib.org%s" />
+        <link rel="canonical" href="https://matplotlib.org%s" />
+    </head>
+    <body>
+        <h1>
+            The page been moved to <a href="https://matplotlib.org%s"</a>
+        </h1>
+    </body>
+</html>
+"""
+
+
+def do_links(root0):
+    """
+    Either soft link a file at the top level to its newest position,
+    or make an html redirect if it is an html file.
+    """
+    _log.info(f'Doing links on {root0}')
+    for root, dirs, files in os.walk(root0):
+        for name in files:
+            fullname = os.path.join(root, name)
+            last = findlast(fullname, tocheck)
+            _log.debug(f'Checking: {fullname} found {last}')
+            if last is not None:
+                os.remove(fullname)
+                if name.endswith(('.htm', '.html')):
+                    # make an html redirect.
+                    _log.info(f'Rewriting HTML: {fullname} in {last}')
+                    with open(fullname, 'w') as fout:
+                        oldname = '/' + os.path.join(last, fullname)
+                        st = html_redirect % (oldname, oldname, oldname)
+                        fout.write(st)
+                else:
+                    # soft link
+                    # Need to do these relative to where the link is
+                    # so if it is a level down `ln -s ../3.1.1/boo/who boo/who`
+                    last = os.path.join('..', last)
+                    depth = root.count('/')
+                    for i in range(depth):
+                        last = os.path.join('..', last)
+                    oldname = os.path.join(last, fullname)
+                    _log.info(f'Linking {fullname} to {oldname}')
+                    os.symlink(oldname, fullname)
+        for d in dirs:
+            do_links(d)
+
+
+def do_canonicals(dname):
+    """
+    For each html file in the versioned docs, make the canonical link point
+    to the newest version.
+    """
+    _log.debug(f'Walking {dname}')
+    for root, dirs, files in os.walk(dname):
+        for name in files:
+            fullname = os.path.join(root, name)
+            p = pathlib.Path(fullname)
+            _log.debug(f'Checking {fullname}')
+            if name.endswith(('.htm', '.html')):
+                basename = pathlib.Path(*p.parts[1:])
+                last = findlast(basename, tocheck)
+                if last is not None:
+                    update_canonical(fullname, last)
+
+        for d in dirs:
+            _log.info(f'DIR: {d}')
+            do_canonicals(os.path.join(dname,d))
+
+
+def update_canonical(fullname, last):
+    """
+    Change the canonical link in *fullname* to the same link in the
+    version given by *last*.  We do this with a regexp to prevent
+    removing any other content on a line that has the canonical link.
+
+    Note that if for some reason there are more than one canonical link
+    this will change  all of them.
+    """
+    p = pathlib.Path(fullname)
+    pre = 'https://matplotlib.org/'
+    pnew = pathlib.Path(last, *p.parts[1:])
+    newcanon = f'{pre+str(pnew)}'
+    _log.info(f'{p} to {pre+str(pnew)}')
+    with tempfile.NamedTemporaryFile(delete=False) as fout:
+        with open(fullname, 'rb') as fin:
+            for line in fin:
+                if b'<link rel="canonical"' in line:
+                    new = bytes(f'<link rel="canonical" href="{newcanon}"',
+                                encoding='utf-8')
+                    ll = re.sub(b'<link rel="canonical" href=".*"', new,
+                                line)
+                    _log.debug(f'new {line}->{ll}')
+                    fout.write(ll)
+                else:
+                    fout.write(line)
+    os.rename(fout.name, fullname)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(description='Optional app description')
+
+    parser.add_argument('--np', type=int, help='Number of processors to use')
+    parser.add_argument('--no_canonicals', help='do not do canonical links',
+                        action="store_true")
+    parser.add_argument('--no_redirects', help='do not do redirects links',
+                        action="store_true")
+
+    args = parser.parse_args()
+    if args.np:
+        np = args.np
+    else:
+        np = None
+
+    # html redirect or soft link most things in the top-level directory that
+    # are not other modules or versioned docs.
+    if not args.no_redirects:
+        for entry in os.scandir('./'):
+            if not (entry.name in toignore):
+                if entry.is_dir():
+                    do_links(entry.name)
+                elif entry.name.endswith(('.htm', '.html')):
+                    fullname = entry.name
+                    last = findlast(fullname, tocheck)
+                    _log.debug(f'Checking: {fullname} found {last}')
+                    if last is not None:
+                        os.remove('./'+fullname)
+                        _log.info(f'Rewriting HTML: {fullname} in {last}')
+                        with open(fullname, 'w') as fout:
+                            oldname = '/' + os.path.join(last, fullname)
+                            st = html_redirect % (oldname, oldname, oldname)
+                            fout.write(st)
+        _log.info('Done links and redirects')
+
+    # change the canonical url for all html to the newest version in the docs:
+    if not args.no_canonicals:
+        if np is not None:
+            with multiprocessing.Pool(np) as pool:
+                pool.map(do_canonicals, tocheck[1:])
+        else:
+            for t in tocheck[1:]:
+                do_canonicals(t)

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -81,7 +81,7 @@ html_redirect = """
     </head>
     <body>
         <h1>
-            The page been moved to <a href="%s"</a>
+            The page been moved <a href="%s">here</a>!
         </h1>
     </body>
 </html>

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -76,8 +76,8 @@ html_redirect = """
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="refresh" content="0;%s" />
-        <link rel="canonical" href="url=https://matplotlib.org%s" />
+        <meta http-equiv="refresh" content="0;url=%s" />
+        <link rel="canonical" href="https://matplotlib.org%s" />
     </head>
     <body>
         <h1>

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import functools
 import logging
 import multiprocessing
 import os
@@ -53,22 +54,17 @@ toignore = tocheck + [pathlib.Path(p) for p in [
 logging.basicConfig(level=logging.DEBUG)
 
 
-# beware of triksy mutable defaults!
-def findlast(fname, tocheck, *, _cache={}):
+@functools.cache
+def findlast(fname, tocheck):
     """
     Check the directories listed in ``tocheck`` to see if they have
     ``fname`` in them.  Return the first one found, or None
     """
-    if fname in _cache:
-        return _cache[fname]
     for t in tocheck:
         pnew = t / fname
         if pnew.exists():
-            _cache[fname] = t
             return t
-    else:
-        _cache[fname] = None
-        return None
+    return None
 
 
 html_redirect = """<!DOCTYPE HTML>

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -10,7 +10,7 @@ import tempfile
 import shutil
 
 """
-This script does two things that improve the website organization.
+This script does three things that improve the website organization.
 
 First, we used to host in the root of the webpage, but have now moved to
 ``/stable/``.  We do not want obsolete links to link to nothing (or that has
@@ -20,6 +20,9 @@ an html refresh redirect.
 
 Second, it changes the canonical link in each html file to the newest version
 found of the html file (including stable if its in the latest version.)
+
+Third, the script adds a new div to the top of all the old webpages with
+tag ``olddocs-message`` to warn users that the page is obsolete.  
 
 This script takes a while, and is destructive, so should probably be run on a
 branch and pushed as a PR so it can easily be reverted.

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 import sys
 import tempfile
-
+import shutil
 
 """
 This script does two things that improve the website organization.
@@ -154,7 +154,7 @@ def update_canonical(fullname, last):
                     fout.write(ll)
                 else:
                     fout.write(line)
-    os.rename(fout.name, fullname)
+    shutil.move(fout.name, fullname)
 
 
 if __name__ == "__main__":

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -85,13 +85,13 @@ html_redirect = """<!DOCTYPE HTML>
 # note these are all one line so they are easy to search and replace in the
 # html files (otherwise we need to close tags)
 warn_banner_exists = (
-    '<div id="olddocs-message"> You are reading an old version of the '
+    '<div id="unreleased-message"> You are reading an old version of the '
     'documentation (v{version}).  For the latest version see '
     '<a href="{url}">{url}</a></div>\n')
 
 
 warn_banner_old = (
-    '<div id="olddocs-message"> You are reading an old version of the '
+    '<div id="unreleased-message"> You are reading an old version of the '
     'documentation (v{version}).  For the latest version see '
     '<a href="/stable/">https://matplotlib.org/stable/</a> </div>\n')
 

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -54,17 +54,18 @@ def findlast(fname, tocheck):
     else:
         return None
 
+
 html_redirect = """
 <!DOCTYPE HTML>
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="refresh" content="0;url=https://matplotlib.org%s" />
-        <link rel="canonical" href="https://matplotlib.org%s" />
+        <meta http-equiv="refresh" content="0;%s" />
+        <link rel="canonical" href="url=https://matplotlib.org%s" />
     </head>
     <body>
         <h1>
-            The page been moved to <a href="https://matplotlib.org%s"</a>
+            The page been moved to <a href="%s"</a>
         </h1>
     </body>
 </html>

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -44,7 +44,7 @@ toignore = tocheck + [pathlib.Path(p) for p in [
     "mpl_toolkits",
     "_webpageutils",
     "xkcd",
-    "sitemap.xml",
+    "_sitemap",
     "robots.txt",
     "CNAME",
     ".git",

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -73,12 +73,12 @@ html_redirect = """
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="refresh" content="0;%s" />
-        <link rel="canonical" href="url=https://matplotlib.org%s" />
+        <meta http-equiv="refresh" content="0;url=%s" />
+        <link rel="canonical" href="https://matplotlib.org%s" />
     </head>
     <body>
         <h1>
-            The page been moved to <a href="%s"</a>
+            The page been moved <a href="%s">here</a>!
         </h1>
     </body>
 </html>

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -162,16 +162,19 @@ def update_canonical(fullname, last):
     pnew = pathlib.Path(last, *p.parts[1:])
     newcanon = f"{pre+str(pnew)}"
     _log.info(f"{p} to {pre+str(pnew)}")
+    rec = re.compile(b'<link rel="canonical" href=".*"')
     with tempfile.NamedTemporaryFile(delete=False) as fout:
+        found = False
         with open(fullname, "rb") as fin:
             for line in fin:
-                if b'<link rel="canonical"' in line:
+                if not found and b'<link rel="canonical"' in line:
                     new = bytes(
                         f'<link rel="canonical" href="{newcanon}"', encoding="utf-8"
                     )
-                    ll = re.sub(b'<link rel="canonical" href=".*"', new, line)
+                    ll = rec.sub(new, line)
                     _log.debug(f"new {line}->{ll}")
                     fout.write(ll)
+                    found = True
                 else:
                     fout.write(line)
     shutil.move(fout.name, fullname)

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -1,12 +1,9 @@
 import argparse
-import glob
 import logging
 import multiprocessing
 import os
 import pathlib
 import re
-import subprocess
-import sys
 import tempfile
 import shutil
 
@@ -89,14 +86,16 @@ html_redirect = """
 
 # note these are all one line so they are easy to search and replace in the
 # html files (otherwise we need to close tags)
-warn_banner_exists = ('<div id="olddocs-message"> You are reading an old '
-        'version of the documentation (v%s).  For the latest version see '
-        '<a href="%s">%s</a></div>\n')
+warn_banner_exists = (
+    '<div id="olddocs-message"> You are reading an old version of the'
+    'documentation (v%s).  For the latest version see '
+    '<a href="%s">%s</a></div>\n')
 
 
-warn_banner_old = ('<div id="olddocs-message"> You are reading an old '
-        'version of the documentation (v%s).  For the latest version see '
-        '<a href="/stable/">https://matplotlib.org/stable/</a> </div>\n')
+warn_banner_old = (
+    '<div id="olddocs-message"> You are reading an old version of the'
+    'documentation (v%s).  For the latest version see '
+    '<a href="/stable/">https://matplotlib.org/stable/</a> </div>\n')
 
 
 def do_links(root0):
@@ -152,7 +151,7 @@ def do_canonicals(dname):
                 basename = pathlib.Path(*p.parts[1:])
                 last = findlast(basename, tocheck)
                 if last is not None:
-                    update_canonical(fullname, last, dname==tocheck[1])
+                    update_canonical(fullname, last, dname == tocheck[1])
 
 
 def update_canonical(fullname, last, newest):
@@ -162,26 +161,23 @@ def update_canonical(fullname, last, newest):
     removing any other content on a line that has the canonical link.
 
     Also add a banner (div) in the body if an old version of the docs.
-    
+
     Note that if for some reason there are more than one canonical link
     this will change  all of them.
     """
     p = pathlib.Path(fullname)
     pre = "https://matplotlib.org/"
     pnew = pathlib.Path(last, *p.parts[1:])
-    newcanon = f"{pre+str(pnew)}"
-    _log.info(f"{p} to {pre+str(pnew)}")
+    newcanon = f"{pre}{str(pnew)}"
+    _log.info(f"{p} to {pre}{str(pnew)}")
     rec = re.compile(b'<link rel="canonical" href=".*"')
     with tempfile.NamedTemporaryFile(delete=False) as fout:
         found = False
         with open(fullname, "rb") as fin:
             for line in fin:
                 if not found and b'<link rel="canonical"' in line:
-                    new = bytes(
-                        f'<link rel="canonical" href="{newcanon}"',
-                        encoding="utf-8"
-                    )
-                    ll = rec.sub(new, line)
+                    new = f'<link rel="canonical" href="{newcanon}"'
+                    ll = rec.sub(new.encode("utf-8"), line)
                     _log.debug(f"new {line}->{ll}")
                     fout.write(ll)
                     found = True
@@ -194,11 +190,10 @@ def update_canonical(fullname, last, newest):
                                                     newcanon)
                     else:
                         new = warn_banner_old % (p.parts[0])
-                    fout.write(bytes(new, encoding="utf-8"))
-                    if not b'<div id="olddocs-message">' in line:
-                        # write the line out if it wasnt' an olddocs-message:
+                    fout.write(new.encode("utf-8"))
+                    if b'<div id="olddocs-message">' not in line:
+                        # write the line out if it wasn't an olddocs-message:
                         fout.write(line)
-
 
                 else:
                     fout.write(line)
@@ -211,12 +206,10 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Optional app description")
 
     parser.add_argument("--np", type=int, help="Number of processors to use")
-    parser.add_argument(
-        "--no_canonicals", help="do not do canonical links", action="store_true"
-    )
-    parser.add_argument(
-        "--no_redirects", help="do not do redirects links", action="store_true"
-    )
+    parser.add_argument("--no_canonicals", help="do not do canonical links",
+                        action="store_true")
+    parser.add_argument("--no_redirects", help="do not do redirects links",
+                        action="store_true")
 
     args = parser.parse_args()
     if args.np:
@@ -244,7 +237,8 @@ if __name__ == "__main__":
                         _log.info(f"Rewriting HTML: {fullname} in {last}")
                         with open(fullname, "w") as fout:
                             oldname = os.path.join(last, fullname)
-                            st = html_redirect % (oldname, "/" + oldname, oldname)
+                            st = html_redirect % (oldname, "/" + oldname,
+                                                  oldname)
                             fout.write(st)
         _log.info("Done links and redirects")
 

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -26,17 +26,28 @@ This script takes a while, and is destructive, so should probably be run on a
 branch and pushed as a PR so it can easily be reverted.
 """
 
-_log = logging.getLogger('make_redirect_links')
+_log = logging.getLogger("make_redirect_links")
 
 
-tocheck = ['stable'] + [f'{major}.{minor}.{micro}'
-                        for major in range(6, -1, -1)
-                        for minor in range(6, -1, -1)
-                        for micro in range(6, -1, -1)]
+tocheck = ["stable"] + [
+    f"{major}.{minor}.{micro}"
+    for major in range(6, -1, -1)
+    for minor in range(6, -1, -1)
+    for micro in range(6, -1, -1)
+    if pathlib.Path(f"{major}.{minor}.{micro}").exists()
+]
 
-toignore = tocheck + ['mpl-probscale', 'mpl_examples', 'mpl_toolkits',
-                      '_webpageutils', 'xkcd', 'sitemap.xml',
-                      'robots.txt', 'CNAME', '.git']
+toignore = tocheck + [
+    "mpl-probscale",
+    "mpl_examples",
+    "mpl_toolkits",
+    "_webpageutils",
+    "xkcd",
+    "sitemap.xml",
+    "robots.txt",
+    "CNAME",
+    ".git",
+]
 
 logging.basicConfig(level=logging.DEBUG)
 

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import logging
 import multiprocessing


### PR DESCRIPTION
(Update 31 Jan 2021):

closes: https://github.com/matplotlib/matplotlib/issues/12374
closes: #25 

Obviously this blows git hub up, but the script that does this is in the first commit...

## Problem 1:  

Currently the top level of the website has a copy of every file that has existed on our webpage, even if the file is obsolete, and not part of current matplotlib docs.  For instance the `/examples/` directory was removed after 2.0.2 (and replaced by `/gallery/`) but is still accessible at https://matplotlib.org/examples/.  @tacaswell wants this to remain so old links do not die, but it also means that search engines think this is a perfectly acceptable current set of webpages, whereas we would like these versions to not show up in searches. 

### Proposed solution:

The script here either soft links all top-level files to their *newest* version in the docs, or makes an html-refresh to do that. 

So, for example `gallery/api` was moved for 3.0.0, so: `ls -halt gallery/api` gives:

```
-rw-r--r--  1 jklymak staff  463 Jan 20 22:24 quad_bezier.html
lrwxr-xr-x  1 jklymak staff   33 Jan 20 22:24 legend.py -> ../../2.2.5/gallery/api/legend.py
-rw-r--r--  1 jklymak staff  463 Jan 20 22:24 radar_chart.html
-rw-r--r--  1 jklymak staff  448 Jan 20 22:24 logos2.html
lrwxr-xr-x  1 jklymak staff   34 Jan 20 22:24 legend.png -> ../../2.2.5/gallery/api/legend.png
```

and `less quad_bezier.html` gives 

```
<!DOCTYPE HTML>
<html lang="en">
    <head>
        <meta charset="utf-8">
        <meta http-equiv="refresh" content="0;url=https://matplotlib.org/2.2.5/gallery/api/quad_bezier.html" />
        <link rel="canonical" href="https://matplotlib.org/2.2.5/gallery/api/quad_bezier.html" />
    </head>
    <body>
        <h1>
            The page been moved to <a href="https://matplotlib.org/2.2.5/gallery/api/quad_bezier.html"</a>
        </h1>
    </body>
</html>
```

## Problem 2:

Similarly our canonical links go to the top level or the level they were introduced in.  So `https://matplotlib.org/stable/gallery/showcase/mandelbrot.html` has `<link rel="canonical" href="https://matplotlib.org/3.3.4/gallery/showcase/mandelbrot.html"/>` as its canonical link.  Older versions of the docs would link to `<link rel="canonical" href="https://matplotlib.org/gallery/showcase/mandelbrot.html"/>`


### Solution:

The script goes through each html file in all versions (including old versions) and changes the canonical link to the newest version.  So for `quad_bezier.html`:

`less 2.2.5/gallery/api/quad_bezier.html` gives `<link rel="canonical" href="https://matplotlib.org/2.2.5/gallery/api/quad_bezier.html" />`

`less 2.2.4/gallery/api/quad_bezier.html` gives the same link (because 2.2.5 is the newest).

For files that exist in `stable`: 

`less 2.2.4/tutorials/intermediate/artists.html` gives the canonical version in stable. 
`<link rel="canonical" href="https://matplotlib.org/stable/tutorials/intermediate/artists.html" />`

## Maintenance Burden

- the script will need updating if a new top-level subdirectory is added and we don't want it included in the linking
- the script needs to be run when a new version of the docs is released; the script is slow, but I added multi-processing to the canonical links part to move it along.  


