### PR TITLE
FIX: update versions.html for 3.3.4

### DIFF
--- a/versions.html
+++ b/versions.html
@@ -1,5 +1,5 @@
-<p><strong>Latest release</strong><br>
-3.3.3: <a href="https://matplotlib.org/3.3.3/index.html">docs</a> | <a href="https://matplotlib.org/3.3.3/users/whats_new.html">changelog</a></p>
+<p><strong>Latest stable release</strong><br>
+3.3.4: <a href="https://matplotlib.org/stable/index.html">docs</a> | <a href="https://matplotlib.org/stable/users/whats_new.html">changelog</a></p>
 <p><strong>Last release for Python 2</strong><br>
 2.2.5: <a href="https://matplotlib.org/2.2.5/index.html">docs</a> | <a href="https://matplotlib.org/2.2.5/users/whats_new.html">changelog</a></p>
 <p><strong>Development version</strong><br>


### PR DESCRIPTION
This got forgotten in the 3.3.4 update...  I also changed the link to stable (instead of hardcoding the version)