### PR TITLE
FIX: update css for banner

### DIFF
--- a/1.2.1/_static/mpl.css
+++ b/1.2.1/_static/mpl.css
@@ -505,3 +505,28 @@ ul.search li div.context {
 ul.keywordmatches li.goodmatch a {
     font-weight: bold;
 }
+
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+
+}

--- a/1.3.0/_static/mpl.css
+++ b/1.3.0/_static/mpl.css
@@ -566,3 +566,27 @@ table.docutils td {
   width: 30em;
 }
 
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+
+}

--- a/1.3.1/_static/mpl.css
+++ b/1.3.1/_static/mpl.css
@@ -566,3 +566,27 @@ table.docutils td {
   width: 30em;
 }
 
+
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}

--- a/1.4.0/_static/mpl.css
+++ b/1.4.0/_static/mpl.css
@@ -650,3 +650,27 @@ figcaption {
 }
 
 
+
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}

--- a/1.4.1/_static/mpl.css
+++ b/1.4.1/_static/mpl.css
@@ -650,3 +650,27 @@ figcaption {
 }
 
 
+
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}

--- a/1.4.2/_static/mpl.css
+++ b/1.4.2/_static/mpl.css
@@ -650,3 +650,27 @@ figcaption {
 }
 
 
+
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}

--- a/1.4.3/_static/mpl.css
+++ b/1.4.3/_static/mpl.css
@@ -650,3 +650,27 @@ figcaption {
 }
 
 
+
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}

--- a/1.5.0/_static/mpl.css
+++ b/1.5.0/_static/mpl.css
@@ -650,3 +650,27 @@ figcaption {
 }
 
 
+
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}

--- a/1.5.1/_static/mpl.css
+++ b/1.5.1/_static/mpl.css
@@ -682,3 +682,27 @@ figcaption {
     background: #003c63;
     outline-color: #003c63;
 }
+
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}

--- a/1.5.3/_static/mpl.css
+++ b/1.5.3/_static/mpl.css
@@ -682,3 +682,27 @@ figcaption {
     background: #003c63;
     outline-color: #003c63;
 }
+
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}

--- a/2.0.0/_static/mpl.css
+++ b/2.0.0/_static/mpl.css
@@ -786,3 +786,27 @@ div.responsive_subfig img {
     }
 
 }
+
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}

--- a/2.0.1/_static/mpl.css
+++ b/2.0.1/_static/mpl.css
@@ -787,3 +787,27 @@ div.responsive_subfig img {
     }
 
 }
+
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}

--- a/2.0.2/_static/mpl.css
+++ b/2.0.2/_static/mpl.css
@@ -787,3 +787,27 @@ div.responsive_subfig img {
     }
 
 }
+
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}

--- a/_websiteutils/fixcss.py
+++ b/_websiteutils/fixcss.py
@@ -1,0 +1,56 @@
+import pathlib
+import tempfile
+import shutil
+
+tocheck =  [
+    pathlib.Path(f"{major}.{minor}.{micro}")
+    for major in range(2, -1, -1)
+    for minor in range(6, -1, -1)
+    for micro in range(6, -1, -1)
+]
+
+
+to_add = b"""
+/* "Go to released version" message. */
+#unreleased-message {
+  background: #d62728;
+  box-sizing: border-box;
+  color: #fff;
+  font-weight: bold;
+  left: 0;
+  min-height: 3em;
+  padding: 0.7em;
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 10000;
+}
+
+#unreleased-message + div {
+  margin-top: 3em;
+}
+
+#unreleased-message a {
+  color: #fff;
+  text-decoration:underline;
+}
+"""
+
+for d in tocheck:
+
+    fname = pathlib.Path(d, '_static', 'mpl.css')
+    if fname.is_file():
+        print(f'checking {fname}')
+        with open(fname) as f:
+            if not "#unreleased-message" in f.read():
+                doit = True
+            else:
+                doit = False
+        if doit:
+            print(f'doing {d}')
+            with tempfile.NamedTemporaryFile(delete=False) as fout:
+                with open(fname, 'rb') as f:
+                    fout.write(f.read())
+                fout.write(to_add)
+            print(f.name)
+            shutil.move(fout.name, f.name)


### PR DESCRIPTION
Older css didn't have an `unreleased-message` tag, and hence the new banner wasn't very visible on older pages:  

https://matplotlib.org/2.0.2/index.html

This adds the css.  I put the little utility in `_websiteutils` just for posterity, rather than any desire to share this.  Happy to remove it.  

This does look a touch ugly, but, they are old docs, and I would suggest its OK...

<img width="1304" alt="NewBanner" src="https://user-images.githubusercontent.com/1562854/107833917-9680dd80-6d49-11eb-8f60-c13c76ee5337.png">
