### PR TITLE
FIX: backlink mpl_toolkits mpl_examples

### DIFF
--- a/_sitemap/sitemap.xml
+++ b/_sitemap/sitemap.xml
@@ -56,11 +56,6 @@
       <priority>1.0</priority>
    </url>
    <url>
-      <loc>http://matplotlib.org/mpl_toolkits/</loc>
-      <changefreq>monthly</changefreq>
-      <priority>1.0</priority>
-   </url>
-   <url>
       <loc>http://matplotlib.org/cmocean/</loc>
       <changefreq>monthly</changefreq>
       <priority>1.0</priority>

--- a/_websiteutils/make_redirects_links.py
+++ b/_websiteutils/make_redirects_links.py
@@ -41,8 +41,6 @@ tocheck = [pathlib.Path("stable")] + [
 
 toignore = tocheck + [pathlib.Path(p) for p in [
     "mpl-probscale",
-    "mpl_examples",
-    "mpl_toolkits",
     "_webpageutils",
     "xkcd",
     "_sitemap",


### PR DESCRIPTION
We'd excluded `mpl_examples` and `mpl_toolkits` from the back-linking, but those actually exist in old versions of the webpages, so it would be better to softlink back to those.  