### PR TITLE
DOC: replace redirect on top-level index.html with static page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,342 @@
-<!DOCTYPE HTML>
-<html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="refresh" content="0;url=stable/index.html" />
-        <link rel="canonical" href="https://matplotlib.org/stable/index.html" />
-    </head>
-    <body>
-        <h1>
-            The page been moved <a href="stable/index.html">here</a>!
-        </h1>
-    </body>
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Matplotlib: Python plotting &#8212; Matplotlib 3.3.4 documentation</title>
+    <link rel="stylesheet" href="_static/mpl.css?v3.3.4" type="text/css" />
+    <link rel="stylesheet" href="_static/pygments.css" type="text/css" />
+    <link rel="stylesheet" type="text/css" href="_static/graphviz.css" />
+    <link rel="stylesheet" type="text/css" href="_static/copybutton.css" />
+    <link rel="stylesheet" type="text/css" href="_static/gallery.css" />
+    <link rel="stylesheet" type="text/css" href="_static/gallery-binder.css" />
+    <link rel="stylesheet" type="text/css" href="_static/gallery-dataframe.css" />
+    <link rel="stylesheet" type="text/css" href="_static/gallery-rendered-html.css" />
+    <script id="documentation_options" data-url_root="./" src="_static/documentation_options.js"></script>
+    <script src="_static/jquery.js"></script>
+    <script src="_static/underscore.js"></script>
+    <script src="_static/doctools.js"></script>
+    <script src="_static/language_data.js"></script>
+    <script src="_static/clipboard.min.js"></script>
+    <script src="_static/copybutton.js"></script>
+    <script async="async" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <link rel="search" type="application/opensearchdescription+xml"
+          title="Search within Matplotlib 3.3.4 documentation"
+          href="_static/opensearch.xml"/>
+    <link rel="shortcut icon" href="_static/favicon.ico"/>
+
+    <link rel="index" title="Index" href="stable/genindex.html" />
+    <link rel="search" title="Search" href="stable/search.html" />
+    <link rel="top" title="Matplotlib 3.3.4 documentation" href="#" />
+    <link rel="canonical" href="https://matplotlib.org/stable/index.html" />
+
+  <link rel="stylesheet" href="_static/custom.css" type="text/css" />
+
+
+  <meta name="viewport" content="width=device-width, initial-scale=0.9, maximum-scale=0.9" />
+
+  </head><body>
+
+
+<!--
+<div id="annc-banner">
+
+</div>
+-->
+
+<div style="background-color: white; text-align: left; padding: 10px 10px 15px 15px; position: relative;">
+    <a href="stable/index.html">
+        <div style="float: left; position: absolute; width: 496px; bottom: 0; padding-bottom: 24px"><span style="float: right; color: #789; background: white">Version 3.3.4</span></div>
+        <img src="_static/logo2_compressed.svg" height="125px" border="0" alt="matplotlib"/></a>
+
+    <!-- The "Fork me on github" ribbon -->
+    <div id="forkongithub"><a href="https://github.com/matplotlib/matplotlib">Fork me on GitHub</a></div>
+    </div>
+
+    <nav class="main-nav">
+        <ul>
+            <li><a href="stable/users/installing.html">Installation</a></li>
+            <li><a href="stable/contents.html">Documentation</a></li>
+            <li><a href="stable/gallery/index.html">Examples</a></li>
+            <li><a href="stable/tutorials/index.html">Tutorials</a></li>
+            <li><a href="stable/devel/index.html">Contributing</a></li>
+            <li class="nav-right">
+                <form class="search" action="search.html" method="get">
+                <input type="text" name="q" aria-labelledby="searchlabel" placeholder="Search"/>
+                </form>
+            </li>
+        </ul>
+     </nav>
+    <div class="related" role="navigation" aria-label="related navigation">
+      <h3>Navigation</h3>
+      <ul>
+        <li class="right" style="margin-right: 10px">
+          <a href="stable/genindex.html" title="General Index"
+             accesskey="I">index</a></li>
+        <li class="right" >
+          <a href="stable/py-modindex.html" title="Python Module Index"
+             >modules</a> |</li>
+        <li><a href="stable/index.html">home</a>|&nbsp;</li>
+        <li><a href="stable/contents.html">contents</a> &raquo;</li>
+        <li class="nav-item nav-item-this"><a href="stable/index.html">Matplotlib: Python plotting</a></li>
+      </ul>
+    </div>
+
+      <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
+        <div class="sphinxsidebarwrapper"><div class="sidebar-versions">
+<script>
+function getSnippet(id, url) {
+    var req = false;
+    // For Safari, Firefox, and other non-MS browsers
+    if (window.XMLHttpRequest) {
+        try {
+            req = new XMLHttpRequest();
+        } catch (e) {
+            req = false;
+        }
+    } else if (window.ActiveXObject) {
+        // For Internet Explorer on Windows
+        try {
+            req = new ActiveXObject("Msxml2.XMLHTTP");
+        } catch (e) {
+            try {
+            req = new ActiveXObject("Microsoft.XMLHTTP");
+            } catch (e) {
+            req = false;
+            }
+        }
+    }
+    var element = document.querySelector(".sidebar-versions");
+    if (req) {
+        // Synchronous request, wait till we have it all
+        req.open('GET', url, false);
+        req.send(null);
+        if (req.status == 200) {
+            element.innerHTML = req.responseText;
+        } else {
+            element.innerHTML = "<mark>Could not find Snippet to insert at " + url + "</mark>"
+        }
+    }
+}
+getSnippet('other_versions', '/versions.html');
+</script>
+</div>
+
+
+<div id="sidebar-donations">
+  <a href="https://numfocus.org/donate-to-matplotlib" target="_blank"> <div class="donate_button" >Support Matplotlib</div></a>
+</div>
+        </div>
+      </div>
+
+    <div class="document">
+      <div class="documentwrapper">
+        <div class="bodywrapper">
+
+
+          <div class="body" role="main">
+
+  <div class="section" id="matplotlib-visualization-with-python">
+<h1>Matplotlib: Visualization with Python<a class="headerlink" href="stable/#matplotlib-visualization-with-python" title="Permalink to this headline">¶</a></h1>
+<p>Matplotlib is a comprehensive library for creating static, animated,
+and interactive visualizations in Python.</p>
+<div class="responsive_screenshots">
+   <a href="stable/tutorials/introductory/sample_plots.html">
+      <div class="responsive_subfig">
+      <img align="middle" src="_images/sphx_glr_membrane_thumb.png"
+       border="0" alt="screenshots"/>
+      </div>
+      <div class="responsive_subfig">
+      <img align="middle" src="_images/sphx_glr_histogram_thumb.png"
+       border="0" alt="screenshots"/>
+      </div>
+      <div class="responsive_subfig">
+      <img align="middle" src="_images/sphx_glr_contour_thumb.png"
+       border="0" alt="screenshots"/>
+      </div>
+      <div class="responsive_subfig">
+      <img align="middle" src="_images/sphx_glr_3D_thumb.png"
+       border="0" alt="screenshots"/>
+      </div>
+   </a>
+</div>
+<span class="clear_screenshots"></span><p>Matplotlib makes easy things easy and hard things possible.</p>
+<div class="bullet-box-container docutils container">
+<div class="bullet-box docutils container">
+<p>Create</p>
+<ul class="simple">
+<li>Develop <a class="reference external" href="stable/gallery/index.html">publication quality plots</a> with just a few lines of code</li>
+<li>Use <a class="reference external" href="stable/gallery/index.html#event-handling">interactive figures</a> that can zoom, pan, update...</li>
+</ul>
+</div>
+<div class="bullet-box docutils container">
+<p>Customize</p>
+<ul class="simple">
+<li><a class="reference external" href="stable/tutorials/index.html#tutorials">Take full control</a> of line styles, font properties, axes properties...</li>
+<li><a class="reference external" href="stable/api/index_backend_api.html">Export and embed</a> to a number of file formats and interactive environments</li>
+</ul>
+</div>
+<div class="bullet-box docutils container">
+<p>Extend</p>
+<ul class="simple">
+<li>Explore tailored functionality provided by
+<a class="reference internal" href="stable/thirdpartypackages/index.html"><span class="doc">third party packages</span></a></li>
+<li>Learn more about Matplotlib through the many
+<a class="reference internal" href="stable/resources/index.html"><span class="doc">external learning resources</span></a></li>
+</ul>
+</div>
+</div>
+<div class="section" id="documentation">
+<h2>Documentation<a class="headerlink" href="stable/#documentation" title="Permalink to this headline">¶</a></h2>
+<p>To get started, read the
+  <a class="reference internal" href="stable/users/index.html"><span class="doc">User's Guide</span></a>.</p>
+<p>Trying to learn how to do a particular kind of plot?  Check out the
+<a class="reference internal" href="stable/gallery/index.html"><span class="doc">examples gallery</span></a> or the <a class="reference internal" href="stable/api/pyplot_summary.html"><span class="doc">list of plotting commands</span></a>.</p>
+</div>
+<div class="section" id="join-our-community">
+<h2>Join our community!<a class="headerlink" href="stable/#join-our-community" title="Permalink to this headline">¶</a></h2>
+<p>Matplotlib is a welcoming, inclusive project, and we follow the <a class="reference external" href="https://www.python.org/psf/conduct/">Python
+Software Foundation Code of Conduct</a> in everything we do.</p>
+<h3>Get help</h3>
+<div class="box">
+  <div class="box-item">
+    <img src="_static/fa/discourse-brands.svg" alt="Discourse">
+    <p>Join our community at <a href="https://discourse.matplotlib.org">discourse.matplotlib.org</a>
+    to get help, discuss contributing &amp; development, and share your work.</p>
+  </div>
+  <div class="box-item">
+    <img src="_static/fa/question-circle-regular.svg" alt="Questions">
+    <p>If you have questions, be sure to check the <a href="stable/faq/index.html">FAQ</a>,
+    the <a href="stable/api/index.html">API</a> docs. The full text
+    <a href="stable/search.html">search</a> is a good way to discover the docs including the many examples.</p>
+  </div>
+  <div class="box-item">
+    <img src="_static/fa/stack-overflow-brands.svg" alt="Stackoverflow">
+    <p>Check out the Matplotlib tag on <a href="https://stackoverflow.com/questions/tagged/matplotlib">stackoverflow</a>.</p>
+  </div>
+  <div class="box-item">
+    <img src="_static/fa/gitter-brands.svg" alt="Gitter">
+    <p>Short questions may be posted on the <a href="https://gitter.im/matplotlib/matplotlib">gitter channel</a>.</p>
+  </div>
+</div>
+<hr class='box-sep'>
+<h3>News</h3>
+<div class="box">
+  <div class="box-item">
+    <img src="_static/fa/plus-square-regular.svg" alt="News">
+    <p>To keep up to date with what's going on in Matplotlib, see the
+    <a href="stable/users/whats_new.html">what's new</a> page or browse the
+    <a href="https://github.com/matplotlib/matplotlib">source code</a>.  Anything that could
+    require changes to your existing code is logged in the
+    <a href="stable/api/api_changes.html">API changes</a> file.</p>
+  </div>
+  <div class="box-item">
+    <img src="_static/fa/hashtag-solid.svg" alt="Social media">
+    <ul>
+    <li>Tweet us at <a href="https://twitter.com/matplotlib">@matplotlib</a>!</li>
+    <li>See cool plots on <a href="https://www.instagram.com/matplotart/">@matplotart</a> Instagram!</li>
+    <li>Check out our <a href="https://matplotlib.org/matplotblog/">Blog</a>!</li>
+    </ul>
+  </div>
+</div>
+<hr class='box-sep'>
+<h3>Development</h3>
+<div class="box">
+  <div class="box-item">
+    <img src="_static/fa/github-brands.svg" alt="Github">
+    <p>Matplotlib is hosted on <a href="https://github.com/matplotlib/matplotlib">GitHub</a>.</p>
+    <ul>
+    <li>File bugs and feature requests on the <a href="https://github.com/matplotlib/matplotlib/issues">issue tracker</a>.</li>
+    <li><a href="https://github.com/matplotlib/matplotlib/pulls">Pull requests</a> are always welcome.</li>
+    </ul>
+    <p>It is a good idea to ping us on <a href="https://discourse.matplotlib.org">Discourse</a> as well.</p>
+  </div>
+  <div class="box-item">
+    <img src="_static/fa/envelope-regular.svg" alt="Mailing lists">
+    <p>Mailing lists</p>
+    <ul>
+    <li><a href="https://mail.python.org/mailman/listinfo/matplotlib-users">matplotlib-users</a> for usage questions</li>
+    <li><a href="https://mail.python.org/mailman/listinfo/matplotlib-devel">matplotlib-devel</a> for development</li>
+    <li><a href="https://mail.python.org/mailman/listinfo/matplotlib-announce">matplotlib-announce</a> for project announcements</li>
+    </ul>
+  </div>
+</div><div class="section" id="toolkits">
+<h3>Toolkits<a class="headerlink" href="stable/#toolkits" title="Permalink to this headline">¶</a></h3>
+<p>Matplotlib ships with several add-on <a class="reference internal" href="stable/api/toolkits/index.html"><span class="doc">toolkits</span></a>,
+including 3D plotting with <a class="reference internal" href="stable/api/toolkits/mplot3d.html#module-mpl_toolkits.mplot3d" title="mpl_toolkits.mplot3d"><code class="xref py py-obj docutils literal notranslate"><span class="pre">mplot3d</span></code></a>, axes helpers in <a class="reference internal" href="stable/api/toolkits/axes_grid1.html#module-mpl_toolkits.axes_grid1" title="mpl_toolkits.axes_grid1"><code class="xref py py-obj docutils literal notranslate"><span class="pre">axes_grid1</span></code></a> and axis
+helpers in <a class="reference internal" href="stable/api/toolkits/axisartist.html#module-mpl_toolkits.axisartist" title="mpl_toolkits.axisartist"><code class="xref py py-obj docutils literal notranslate"><span class="pre">axisartist</span></code></a>.</p>
+</div>
+<div class="section" id="third-party-packages">
+<h3>Third party packages<a class="headerlink" href="stable/#third-party-packages" title="Permalink to this headline">¶</a></h3>
+<p>A large number of <a class="reference internal" href="stable/thirdpartypackages/index.html"><span class="doc">third party packages</span></a>
+extend and build on Matplotlib functionality, including several higher-level
+plotting interfaces (<a class="reference external" href="https://seaborn.pydata.org">seaborn</a>, <a class="reference external" href="https://holoviews.org">HoloViews</a>, <a class="reference external" href="http://ggplot.yhathq.com">ggplot</a>, ...), and a projection
+and mapping toolkit (<a class="reference external" href="https://scitools.org.uk/cartopy/docs/latest">Cartopy</a>).</p>
+</div>
+<div class="section" id="citing-matplotlib">
+<h3>Citing Matplotlib<a class="headerlink" href="stable/#citing-matplotlib" title="Permalink to this headline">¶</a></h3>
+<p>Matplotlib is the brainchild of John Hunter (1968-2012), who, along with its
+many contributors, have put an immeasurable amount of time and effort into
+producing a piece of software utilized by thousands of scientists worldwide.</p>
+<p>If Matplotlib contributes to a project that leads to a scientific publication,
+please acknowledge this work by citing the project. A <a class="reference internal" href="stable/citing.html"><span class="doc">ready-made citation
+entry</span></a> is available.</p>
+</div>
+<div class="section" id="open-source">
+<h3>Open source<a class="headerlink" href="stable/#open-source" title="Permalink to this headline">¶</a></h3>
+<a href="https://numfocus.org/">
+<img src="_static/numfocus_badge.png"
+ alt="A Fiscally Sponsored Project of NUMFocus"
+ style="float:right; margin-left:20px" />
+</a><p>Matplotlib is a Sponsored Project of NumFOCUS, a 501(c)(3) nonprofit
+charity in the United States. NumFOCUS provides Matplotlib with
+fiscal, legal, and administrative support to help ensure the health
+and sustainability of the project. Visit <a class="reference external" href="https://numfocus.org">numfocus.org</a> for more
+information.</p>
+<p>Donations to Matplotlib are managed by NumFOCUS. For donors in the
+United States, your gift is tax-deductible to the extent provided by
+law. As with any donation, you should consult with your tax adviser
+about your particular tax situation.</p>
+<p>Please consider <a class="reference external" href="https://numfocus.org/donate-to-matplotlib">donating to the Matplotlib project</a> through
+the NumFOCUS organization or to the <a class="reference external" href="https://numfocus.org/programs/john-hunter-technology-fellowship/">John Hunter Technology Fellowship</a>.</p>
+<p>The <a class="reference internal" href="stable/users/license.html"><span class="doc">Matplotlib license</span></a> is based on the <a class="reference external" href="https://www.python.org/psf/license">Python Software
+Foundation (PSF) license</a>.</p>
+<p>There is an active developer community and a long list of people who have made
+significant <a class="reference internal" href="stable/users/credits.html"><span class="doc">contributions</span></a>.</p>
+</div>
+</div>
+</div>
+
+
+          </div>
+
+        </div>
+      </div>
+      <div class="clearer"></div>
+    </div>
+<footer>
+    <div class="footer">
+    &copy; Copyright 2002 - 2012 John Hunter, Darren Dale, Eric Firing, Michael Droettboom and the Matplotlib development team; 2012 - 2021 The Matplotlib development team.
+<br />
+    Last updated on Jan 28, 2021.
+Created using
+<a href="http://sphinx-doc.org/">Sphinx</a> 3.1.1.
+Doc version v3.3.4.
+    </div>
+</footer>
+<script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+        ga('create', 'UA-55954603-1', 'auto');
+        ga('send', 'pageview');
+
+</script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
             <li><a href="stable/tutorials/index.html">Tutorials</a></li>
             <li><a href="stable/devel/index.html">Contributing</a></li>
             <li class="nav-right">
-                <form class="search" action="search.html" method="get">
+                <form class="search" action="stable/search.html" method="get">
                 <input type="text" name="q" aria-labelledby="searchlabel" placeholder="Search"/>
                 </form>
             </li>


### PR DESCRIPTION
This is the 3.3.4 index.html with the links all changed to point to stable/.

In the process of putting this file in a separate repo.