### PR TITLE
Remove inventory redirect

### DIFF
--- a/objects.inv
+++ b/objects.inv
@@ -1,1 +1,0 @@
-stable/objects.inv


### PR DESCRIPTION
Per discussion in
https://github.com/matplotlib/matplotlib/issues/22601#issuecomment-1063217148
this is actually breaking builds in subtle very brittle way as the links that
will be generated will be pointing at the top-level files (that are actually
re-directs to /stable).

The second step of this will be to put a 301 redirect into caddy.