### PR TITLE
MNT: remove 2.2.1 from sitemap

### DIFF
--- a/_sitemap/sitemap.xml
+++ b/_sitemap/sitemap.xml
@@ -178,11 +178,6 @@
       <priority>0.1</priority>
    </url>
    <url>
-      <loc>http://matplotlib.org/2.2.1</loc>
-      <changefreq>yearly</changefreq>
-      <priority>0.1</priority>
-   </url>
-   <url>
       <loc>http://matplotlib.org/2.2.0</loc>
       <changefreq>yearly</changefreq>
       <priority>0.1</priority>


### PR DESCRIPTION
We did not publish docs for v2.2.1