### PR TITLE
MAINT: Exclude devdocs from search engine results

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -6,6 +6,7 @@ User-agent: *
 
 # do not search root directory by default.
 Disallow: /api/
+Disallow: /devdocs/
 Disallow: /devel/
 Disallow: /examples/
 Disallow: /faq/

--- a/robots.txt
+++ b/robots.txt
@@ -6,7 +6,6 @@ User-agent: *
 
 # do not search root directory by default.
 Disallow: /api/
-Disallow: /devdocs/
 Disallow: /devel/
 Disallow: /examples/
 Disallow: /faq/
@@ -39,6 +38,22 @@ Disallow: /py-modindex.html
 Disallow: /search.html
 Disallow: /searchindex.js
 Disallow: /win32_*.tar.gz
+# exclude all of /devdocs except /devdocs/devel
+Disallow: /devdocs/api/
+Disallow: /devdocs/faq/
+Disallow: /devdocs/gallery/
+Disallow: /devdocs/plot_types/
+Disallow: /devdocs/resources/
+Disallow: /devdocs/thirdpartypackages/
+Disallow: /devdocs/tutorials/
+Disallow: /devdocs/users/
+Disallow: /devdocs/citing.html
+Disallow: /devdocs/contents.html
+Disallow: /devdocs/index.html
+Disallow: /devdocs/objects.inv
+Disallow: /devdocs/py-modindex.html
+Disallow: /devdocs/search.html
+Disallow: /devdocs/searchindex.js
 
 # tell robots this is sitemap
 Sitemap: https://matplotlib.org/_sitemap/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -39,21 +39,8 @@ Disallow: /search.html
 Disallow: /searchindex.js
 Disallow: /win32_*.tar.gz
 # exclude all of /devdocs except /devdocs/devel
-Disallow: /devdocs/api/
-Disallow: /devdocs/faq/
-Disallow: /devdocs/gallery/
-Disallow: /devdocs/plot_types/
-Disallow: /devdocs/resources/
-Disallow: /devdocs/thirdpartypackages/
-Disallow: /devdocs/tutorials/
-Disallow: /devdocs/users/
-Disallow: /devdocs/citing.html
-Disallow: /devdocs/contents.html
-Disallow: /devdocs/index.html
-Disallow: /devdocs/objects.inv
-Disallow: /devdocs/py-modindex.html
-Disallow: /devdocs/search.html
-Disallow: /devdocs/searchindex.js
+Disallow: /devdocs/
+Allow: /devdocs/devel/
 
 # tell robots this is sitemap
 Sitemap: https://matplotlib.org/_sitemap/sitemap.xml


### PR DESCRIPTION
Recently, a search engine [linked a user](https://github.com/matplotlib/matplotlib/pull/24691#issuecomment-1608993175) to the devdocs. This change should help guide users to the current docs instead of the devdocs. 