### PR TITLE
Added color sequence page to Colors

### DIFF
--- a/3.9.2/users/explain/colors/colors.html
+++ b/3.9.2/users/explain/colors/colors.html
@@ -518,6 +518,8 @@ document.write(`
 <li class="toctree-l2"><a class="reference internal" href="colormap-manipulation.html">Creating Colormaps in Matplotlib</a></li>
 <li class="toctree-l2"><a class="reference internal" href="colormapnorms.html">Colormap normalization</a></li>
 <li class="toctree-l2"><a class="reference internal" href="colormaps.html">Choosing Colormaps in Matplotlib</a></li>
+<li class="toctree-l2"><a class="reference internal" href="colorsequence.html">Color Sequences in Matplotlib</a></li>
+
 </ul>
 </details></li>
 </ul>

--- a/3.9.2/users/explain/colors/colorsequence.html
+++ b/3.9.2/users/explain/colors/colorsequence.html
@@ -625,74 +625,33 @@ document.write(`
         <h1>Petroff Color Sequence<a class="headerlink" href="#colormap-normalization" title="Link to this heading">#</a></h1>
         <p>The <strong>Petroff color sequence</strong> is a visually appealing color scheme in Matplotlib designed for clarity in data visualizations. It smoothly transitions between colors, making it ideal for graphs where clear distinctions between data points are necessary, like line plots or bar charts.</p>
       
-        <p>To use the Petroff color sequence in Matplotlib, simply reference it by its name, <code>'petroff10'</code>, when setting the color map in your plots.</p>
+        <p>To use the Petroff color sequence in Matplotlib, simply reference it by its name, <code>'petroff10'</code>, when setting the colormap in your plots.</p>
       
         <p>To add or remove color sequences in Matplotlib, you can use the <code>ColorSequenceRegistry</code> class's <code>register</code> and <code>unregister</code> functions. The <code>register</code> function allows you to add a custom color sequence by specifying a unique name and a list of colors. Once registered, the color sequence can be accessed by name in Matplotlib.</p>
-    
-        <h2 id="code-snippet">Code Snippet for Registering and Using a Custom Color Sequence</h2>
+      
+        <p>Here’s a code snippet demonstrating how to register and unregister a color sequence:</p>
+      
         <pre><code>
-import matplotlib.pyplot as plt
-import matplotlib as mpl
-
-# Register a custom color sequence
-mpl.color_sequences.register('my_sequence', ['#FF0000', '#00FF00', '#0000FF'])
-
-# Access and use the custom color sequence
-cmap = mpl.color_sequences['my_sequence']
-print(cmap)  # Outputs: ['#FF0000', '#00FF00', '#0000FF']
-
-# Unregister the custom color sequence
-mpl.color_sequences.unregister('my_sequence')
+      import matplotlib as mpl
+      
+      # Register a new color sequence
+      mpl.color_sequences.register('my_sequence', ['#FF0000', '#00FF00', '#0000FF'])
+      
+      # Access the newly registered color sequence
+      cmap = mpl.color_sequences['my_sequence']
+      print(cmap)  # Outputs: ['#FF0000', '#00FF00', '#0000FF']
+      
+      # Unregister the custom color sequence
+      mpl.color_sequences.unregister('my_sequence')
         </code></pre>
       
         <p>This code snippet demonstrates how to create, access, and remove custom color sequences. Note that built-in color sequences like 'petroff10' cannot be unregistered as they are predefined by Matplotlib.</p>
-    
-        <h2 id="example-plot">Example Plot Using the Petroff Color Sequence</h2>
-        <p>The example below shows how to apply the <code>'petroff10'</code> color sequence to a Matplotlib line plot.</p>
       
-        <pre><code>
-import matplotlib.pyplot as plt
-import numpy as np
-import matplotlib as mpl
-
-# Data preparation
-x = np.linspace(0, 10, 100)
-y = [np.sin(x + phase) for phase in np.linspace(0, np.pi, 5)]
-
-# Plot using the petroff10 color sequence
-plt.figure()
-for i, y_values in enumerate(y):
-    plt.plot(x, y_values, label=f'Line {i+1}', color=mpl.color_sequences['petroff10'][i])
-plt.legend()
-plt.title('Example Plot Using the Petroff Color Sequence')
-plt.xlabel('X-axis')
-plt.ylabel('Y-axis')
-plt.show()
-        </code></pre>
-    
-        <p>For further insights into effective color choices for data representation, view Colin Ware's study on color sequences <a href="https://ccom.unh.edu/sites/default/files/publications/Ware_1988_CGA_Color_sequences_univariate_maps.pdf" target="_blank">here</a>.</p>
-    </div>
+        <p>For more details on color sequences and effective color choices, you can view Colin Ware's study on color sequences <a href="https://ccom.unh.edu/sites/default/files/publications/Ware_1988_CGA_Color_sequences_univariate_maps.pdf" target="_blank">here</a>.</p>
+      </div>
             
-    <div class="bd-sidebar-secondary bd-toc">
-        <div class="sidebar-secondary-items sidebar-secondary__inner">
-            <div class="sidebar-secondary-item">
-                <div id="pst-page-navigation-heading-2" class="page-toc tocsection onthispage">
-                    <i class="fa-solid fa-list"></i> On this page
-                </div>
-                <nav class="bd-toc-nav page-toc" aria-labelledby="pst-page-navigation-heading-2">
-                    <ul class="visible nav section-nav flex-column">
-                        <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#colormapnorms">Petroff Color Sequence</a></li>
-                        <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#code-snippet">Code Snippet for Registering and Using a Custom Color Sequence</a></li>
-                        <li class="toc-h2 nav-item toc-entry"><a class="reference internal nav-link" href="#example-plot">Example Plot Using the Petroff Color Sequence</a></li>
-                    </ul>
-                </nav>
-            </div>
-        </div>
-    </div>
-</section>
-
-                    
-                           
+         
+            
 
 
 
@@ -737,8 +696,6 @@ plt.show()
   </p>
 </div>
       
-
-
         <div class="footer-item">
   <p class="sphinx-version">
     Built from v3.9.2-3-gd04b2f64fe.


### PR DESCRIPTION
Added page for explaining Color Sequences to users.

Description:
The page can be navigated to from https://matplotlib.org/devdocs/users/explain/colors/index.html. It includes a description of the petroff color sequence, including a Code Snippet for Registering and Using a Custom Color Sequence and an Example of code to create a Plot Using the Petroff Color Sequence. 

Closes #28750 
