### PR TITLE
Add an empty Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,34 @@
+---
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Pages
+        run: |
+          mkdir pages
+          echo matplotlib.org > pages/CNAME
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'pages'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Our repo is too large to deploy to Pages, which is why we use this repo on an external server. However, GitHub keeps trying, and failing, to publish this repo on every commit. For now, I've just kept this around to preserve the redirects from `matplotlib.github.com`.

This change adds a custom workflow that just fills out `CNAME` and publishes that as the "website" on Pages. This avoids both the checkout and the upload of over 10GB that just errors out.