### PR TITLE
Fix the link to lastest stable documentation

### DIFF
--- a/versions.html
+++ b/versions.html
@@ -1,5 +1,5 @@
 <p><strong>Latest stable release</strong><br>
-3.10.1: <a href="https://matplotlib.org/3.10.1/index.html">docs</a> | <a href="https://matplotlib.org/3.10.1/users/release_notes.html">release notes</a></p>
+3.10.5: <a href="https://matplotlib.org/3.10.5/index.html">docs</a> | <a href="https://matplotlib.org/3.10.5/users/release_notes.html">release notes</a></p>
 <p><strong>Last release for Python 2</strong><br>
 2.2.5: <a href="https://matplotlib.org/2.2.5/index.html">docs</a> | <a href="https://matplotlib.org/2.2.5/users/whats_new.html">changelog</a></p>
 <p><strong>Development version</strong><br>


### PR DESCRIPTION
This is for updating the link in the version file to the latest documentation because it's not done automatically. 