### PR TITLE
docs: remove incorrect v9.4 entry from switcher.json (fixes matplotli…

### DIFF
--- a/3.10.5/_static/switcher.json
+++ b/3.10.5/_static/switcher.json
@@ -11,11 +11,6 @@
         "url": "https://matplotlib.org/devdocs/"
     },
     {
-        "name": "3.9",
-        "version": "3.9.3",
-        "url": "https://matplotlib.org/3.9.4/"
-    },
-    {
         "name": "3.8",
         "version": "3.8.4",
         "url": "https://matplotlib.org/3.8.4/"


### PR DESCRIPTION
Fixes matplotlib/matplotlib#30397

Removes the incorrect `9.4` entry from `3.10.5/_static/switcher.json`.
This avoids future confusion in archived documentation. No code changes.
